### PR TITLE
Gitignoreの追記

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /test*.coffee
 /test.litcoffee
 /test*.litcoffee
+*.coffee
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,11 @@
 /public/assets
 .byebug_history
 
+/test.coffee
+/test*.coffee
+/test.litcoffee
+/test*.litcoffee
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+config/secrets.yml


### PR DESCRIPTION
## What?
coffee, secrets.ymlを追記
## Why?
自動生成された使われないファイルを本番環境に入れないため
サーバーアクセスキー等機密情報を一般公開させないため