### PR TITLE
Add ancestry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
 gem 'erb2haml'
 gem 'devise'
+gem 'ancestry'
 
 group :production do
   gem 'unicorn', '5.4.1'


### PR DESCRIPTION
# what
ツリー構造を簡単に作れるgemを導入します。
# why
現在は3世代のみですが、構造が深くなった時にルーティングを変える手間が省けるため。