### PR TITLE
cssの不具合の修正

### DIFF
--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -4,6 +4,6 @@ $gray-lv2:#ccc; //検索窓などのボーダーの色
 $gray-lv1:#f5f5f5; //wrapperなどの背景の色
 
 $link-blue:#0099e8; //パンくずリストに使われている水色
-$link-blue-light:#b3d4fc;//パンくずリスをと洗濯した時の背景色
+$link-blue-light:#b3d4fc; //パンくずリストを選択した時の背景色
 
 $base-red:#ea352d; //メルカリのボタンの赤

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,11 +10,13 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
+ 
  *= require_self
  */
- @import './reset.scss';
- @import './variables';
- @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro');
- @import './common.scss';
- @import './colors.scss';
+ 
+ @import 'reset.scss';
+ @import url("https://fonts.googleapis.com/css?family=Abril+Fatface|Patua+One");
+ @import 'colors.scss';
+ @import 'variables.scss';
+ @import 'common.scss';
+


### PR DESCRIPTION
# what
共通のCSSの中にあった不具合を修正しました。その結果、
*= require_tree .
を削除しました。

# why
CSSを読み込む順番が制御できずエラーがで続けていたためです。

詳細を確認されたい場合、下記をご覧ください。

https://railsguides.jp/asset_pipeline.html#%E3%83%9E%E3%83%8B%E3%83%95%E3%82%A7%E3%82%B9%E3%83%88%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%A8%E3%83%87%E3%82%A3%E3%83%AC%E3%82%AF%E3%83%86%E3%82%A3%E3%83%96