### PR TITLE
サーバー環境でのBasic認証機能導入の一時停止

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,2 @@
 class ApplicationController < ActionController::Base
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,16 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
 
   private
 
+  def production?
+    Rails.env.production?
+  end
+
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == 'admin' && password == '2222'
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,16 +1,3 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth, if: :production?
-  protect_from_forgery with: :exception
 
-  private
-
-  def production?
-    Rails.env.production?
-  end
-
-  def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-    end
-  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,15 +83,6 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  # server "db.example.com", user: "deploy", roles: %w{db}
-  server "18.182.90.204", user: "ec2-user", roles: %w{app db web}
-
-  set :rails_env, "production"
-  set :unicorn_rack_env, "production"
-
-  # role-based syntax
-  # ==================
-
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,15 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
+  # server "db.example.com", user: "deploy", roles: %w{db}
+  server "18.182.90.204", user: "ec2-user", roles: %w{app db web}
+
+  set :rails_env, "production"
+  set :unicorn_rack_env, "production"
+
+  # role-based syntax
+  # ==================
+
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter


### PR DESCRIPTION
## What?
追加したBasic認証機能を取り外すためメソッドを削除
デプロイ環境開発の都合上、前回のプルリクで追加した記述をいったん削除してますので
他に操作してないことを確認していただきたいです。

## Why?
サーバー環境構築の適正化