### PR TITLE
ベーシック認証機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,16 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
 
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,15 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
+  # server "db.example.com", user: "deploy", roles: %w{db}
+  server "13.113.199.8", user: "ec2-user", roles: %w{app db web}
+
+  set :rails_env, "production"
+  set :unicorn_rack_env, "production"
+
+  # role-based syntax
+  # ==================
+
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter


### PR DESCRIPTION
# What?
自動デプロイ機能そのものの動作は確認が取れたので
ベーシック認証機能を追加させてサーバーサイドの稼働を検証します。
※再度追加削除で機能検証する可能性があります。
# Why?
開発中サーバーアプリへの簡易アクセス制限をするため