### PR TITLE
Basic認証機能ファイル修正

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,6 +8,12 @@
 # server "db.example.com", user: "deploy", roles: %w{db}
 server '13.113.199.8', user: 'ec2-user', roles: %w{app db web}
 
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
+
+# role-based syntax
+# ==================
+
 
 # role-based syntax
 # ==================

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,15 +83,6 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  # server "db.example.com", user: "deploy", roles: %w{db}
-  server "13.113.199.8", user: "ec2-user", roles: %w{app db web}
-
-  set :rails_env, "production"
-  set :unicorn_rack_env, "production"
-
-  # role-based syntax
-  # ==================
-
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter


### PR DESCRIPTION
# What?
記述するべきファイルが間違っていたため修正
# Why?
・開発中サーバーアプリに最低限の認証機能を備えて開発チームだけがアクセスできるようにするため。