### PR TITLE
明示的にサーバーに当ブランチの現状を反映させるためのマージ

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -53,6 +53,7 @@ set :ssh_options, auth_methods: ['publickey'],
 set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 
+
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :restart do


### PR DESCRIPTION
# What?
サーバーに反映されるリモートリポジトリを明示的に確認するための空行追加コミット

# Why?
サーバーにきちんとローカル編集したファイルが反映されていることを確認するため