### PR TITLE
ベーシック認証機能を一時オフにします

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,16 +1,3 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth, if: :production?
-  protect_from_forgery with: :exception
 
-  private
-
-  def production?
-    Rails.env.production?
-  end
-
-  def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-    end
-  end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -53,6 +53,7 @@ set :ssh_options, auth_methods: ['publickey'],
 set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 
+
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :restart do

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,11 +8,6 @@
 # server "db.example.com", user: "deploy", roles: %w{db}
 server '13.113.199.8', user: 'ec2-user', roles: %w{app db web}
 
-set :rails_env, "production"
-set :unicorn_rack_env, "production"
-
-# role-based syntax
-# ==================
 
 
 # role-based syntax


### PR DESCRIPTION
# What?
サーバー環境検証用に追加したベーシック認証機能を一時的にオフにします
※このプルリクの少し前にしたリモートリポジトリとローカルのファイル差異確認をした時の空行追加が含まれています。

# Why?
ベーシック認証機能の確認のため