### PR TITLE
ベーシック認証機能の解除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,16 +1,3 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth, if: :production?
-  protect_from_forgery with: :exception
 
-  private
-
-  def production?
-    Rails.env.production?
-  end
-
-  def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-    end
-  end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,11 +8,6 @@
 # server "db.example.com", user: "deploy", roles: %w{db}
 server '13.113.199.8', user: 'ec2-user', roles: %w{app db web}
 
-set :rails_env, "production"
-set :unicorn_rack_env, "production"
-
-# role-based syntax
-# ==================
 
 
 # role-based syntax


### PR DESCRIPTION
# What?
ベーシック認証機能を取り外し、一旦別の機能の実装に取り掛かります。
# Why?
・他の機能実装を進めるため。