### PR TITLE
デプロイエラー修正継続、Uglifier::Error: Unexpected character '`' 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   # config.assets.js_compressor = :uglifier
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  # config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,8 +23,14 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
+
+  
+  # TODO: デプロイ時にjsコンパイル起因とみられるrake aborted! Uglifier::Error: Unexpected character '`' が発生
+  # 以下の本番環境コンフィグを調整中
   # config.assets.js_compressor = :uglifier
   # config.assets.js_compressor = Uglifier.new(harmony: true)
+  
+
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# What?
前回デプロイ自体は成功したものの、jsを持ちいいているトップページのみがwe'reエラー状態になったため修正を模索。
config/environments/production.rb

# Why?
ローカル状態を反映できるデプロイ環境を構築するため