### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
 
   def index # トップページ、アイテムをカテゴリー別に最新投稿順番に
+    @items = Item.all.order(id: "DESC")
   end
 
   def new

--- a/app/views/items/_items-box.html.haml
+++ b/app/views/items/_items-box.html.haml
@@ -1,45 +1,15 @@
 .item-box__container
-  %section.item-box
-    = link_to '各アイテムへのリンク', src: '#' do
-      = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item1"), class: '.item-box__photo'
-      -# = image_tag ("#"), alt: #{'出品タイトル'}, class: #{'ブランド名'} バックエンドができればこちらに差し替え
-    .item-box__info
-      %h3.item-box__info__name アイテム名１
-      .item-box__bottom
-        %p.item-box__bottom__price ¥0,000
-        %p.item-box__bottom__like.icon-like 1
-        %p.item-box__bottom__tax (税込)
-
-  %section.item-box
-    = link_to '各アイテムへのリンク', src: '#' do
-      = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item2")
-      -# = image_tag ("#"), alt: #{'出品タイトル'}, class: #{'ブランド名'} バックエンドができればこちらに差し替え
-    .item-box__info
-      %h3.item-box__info__name アイテム名2
-      .item-box__bottom
-        %p.item-box__bottom__price ¥0,000
-        %p.item-box__bottom__like.icon-like 1
-        %p.item-box__bottom__tax (税込)
-
-  %section.item-box.visible-tablet
-    = link_to '各アイテムへのリンク', src: '#' do
-      = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item3")
-      -# = image_tag ("#"), alt: #{'出品タイトル'}, class: #{'ブランド名'} バックエンドができればこちらに差し替え
-    .item-box__info
-      %h3.item-box__info__name アイテム名3
-      .item-box__bottom
-        %p.item-box__bottom__price ¥0,000
-        %p.item-box__bottom__like.icon-like 1
-        %p.item-box__bottom__tax (税込)
-
-  %section.item-box.visible-full-width
-    = link_to '各アイテムへのリンク', src: '#' do
-      = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item4")
-      -# = image_tag ("#"), alt: #{'出品タイトル'}, class: #{'ブランド名'} バックエンドができればこちらに差し替え
-    .item-box__info
-      %h3.item-box__info__name アイテム名4
-      .item-box__bottom
-        %p.item-box__bottom__price ¥0,000
-        %p.item-box__bottom__like.icon-like 1
-        %p.item-box__bottom__tax (税込)
-        
+  - @items.each do |item|
+    %section.item-box
+      = link_to '各アイテムへのリンク', src: '#' do
+        = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item1"), class: '.item-box__photo'
+        -# = image_tag ("#"), alt: #{'出品タイトル'}, class: #{'ブランド名'} バックエンドができればこちらに差し替え
+      .item-box__info
+        %h3.item-box__info__name
+          = item.name
+        .item-box__bottom
+          %p.item-box__bottom__price
+            ¥
+            = item.price
+          %p.item-box__bottom__like.icon-like 1
+          %p.item-box__bottom__tax (税込)


### PR DESCRIPTION
# WHAT
トップページに出品された商品の一覧を表示する。
・items_controllerに@itemsを定義
・_items-box.html.hamlを編集
＊商品詳細へのリンク、いいね数、商品画像は仮置きのままです。

# WHY
トップページから商品にアクセスできるようにするため。