### PR TITLE
各自の個人的なソース退避用フォルダの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /yarn-error.log
 
 /public/assets
+/public/myfiles
 .byebug_history
 
 /test.coffee


### PR DESCRIPTION
# What?
gitignoreにpublic/myfilesを追加
pushしたくないが、個人的に退避させておきたソースコードなどを
このフォルダ以下にファイル作成して保管してください。

# Why?
プロジェクト内に個人用ソースとマージ用ソースを共存管理させるため