### PR TITLE
ユーザー新規登録（ウィザードフォーム）

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :return_logged_in_user, only: :new
 
   def show  # ユーザー個人ページ、自分の出品した商品を出品ステータス別に得る
 
@@ -6,11 +7,70 @@ class UsersController < ApplicationController
 
 
   def new
-
+    case params[:url]
+    when "registration" then
+      reset_session
+      @user = User.new
+      render "users/signup/#{params[:url]}"
+    when "address" then
+      @user = User.new(user_params)
+      if @user.valid_columns?(:name,:email,:password,:password_confirmation,:last_name,:first_name,:last_name_kana,:first_name_kana,:birthday)
+        session[:name] = params[:user][:name]
+        session[:email] = params[:user][:email]
+        session[:password] = params[:user][:password]
+        session[:password_confirmation] = params[:user][:password_confirmation]
+        session[:last_name] = params[:user][:last_name]
+        session[:first_name] = params[:user][:first_name]
+        session[:last_name_kana] = params[:user][:last_name_kana]
+        session[:first_name_kana] = params[:user][:first_name_kana]
+        session[:"birthday(1i)"] = params[:user][:"birthday(1i)"]
+        session[:"birthday(2i)"] = params[:user][:"birthday(2i)"]
+        session[:"birthday(3i)"] = params[:user][:"birthday(3i)"]
+        render "users/signup/#{params[:url]}"
+      else
+        render "/users/signup/registration"
+      end
+    when "card" then
+      @user = User.new(user_params)
+      if @user.valid_columns?(:postal_code,:prefecture,:city,:address,:building,:phone)
+        session[:postal_code] = params[:user][:postal_code]
+        session[:prefecture] = params[:user][:prefecture]
+        session[:city] = params[:user][:city]
+        session[:address] = params[:user][:address]
+        session[:building] = params[:user][:building]
+        session[:phone] = params[:user][:phone]
+        render "users/signup/#{params[:url]}"
+      else
+        render "/users/signup/address"
+      end
+    when "complete"
+      @user = User.new(name: session[:name],email: session[:email],password: session[:password],password_confirmation: session[:password_confirmation],last_name: session[:last_name],first_name: session[:first_name],last_name_kana: session[:last_name_kana],first_name_kana: session[:first_name_kana],"birthday(1i)": session[:"birthday(1i)"],"birthday(2i)": session[:"birthday(2i)"],"birthday(3i)": session[:"birthday(3i)"],postal_code: session[:postal_code],prefecture: session[:prefecture],city: session[:city],address: session[:address],building: session[:building],phone: session[:phone])
+      @user[:seller_id] = 1
+      @user[:buyer_id] = 1
+      if @user.save
+        @user[:seller_id] = @user.id
+        @user[:buyer_id] = @user.id
+        @user.save
+        reset_session
+        sign_in @user
+        render "users/signup/#{params[:url]}"
+      else
+        render "users/signup/card"
+      end
+    end
   end
 
   def logout
   end
-  
+
+  private
+
+  def return_logged_in_user
+    redirect_to root_path if user_signed_in?
+  end
+
+  def user_params
+    params.require(:user).permit(:name,:email, :password, :password_confirmation, :last_name, :first_name, :last_name_kana, :first_name_kana, :birthday,:postal_code,:prefecture,:city,:address,:building,:phone)
+  end
 
 end

--- a/app/models/concerns/valid_columns.rb
+++ b/app/models/concerns/valid_columns.rb
@@ -1,0 +1,16 @@
+class ActiveRecord::Errors
+  def delete(column)
+    @errors.delete(column.to_s)
+  end
+end
+
+module ActiveRecord::Validations
+  def valid_columns?(*columns)
+    valid?
+    cols = columns.flatten.collect(&:to_s)
+    errors.keys.each do |k|
+      errors.delete(k) unless cols.include?(k.to_s)
+    end
+    errors.empty?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,28 @@
 class User < ApplicationRecord
+  require 'valid_columns'
+
   has_many :likes
   has_many :user_items
   has_many :items, through: :user_items
   belongs_to :card, optional: true
+
+  with_options presence: true do
+    validates :name
+    validates :address
+    validates :first_name
+    validates :last_name
+    validates :first_name_kana
+    validates :last_name_kana
+    validates :postal_code
+    validates :prefecture
+    validates :city
+    validates :address
+    validates :birthday
+  end
+
+  validates :name,            length: { maximum: 20 }
+  validates :first_name_kana, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/ }
+  validates :last_name_kana,  format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/ }
 
   enum prefecture: {
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -6,7 +6,7 @@
         .panel__head
           %p{class: "panel__head__text"} アカウントをお持ちでない方はこちら
           .panel__head__registration-link-btn
-            = link_to "新規会員登録" , new_user_registration_path
+            = link_to "新規会員登録" , new_user_path
         .panel__inner
           .sns-login
             .sns-login__facebook

--- a/app/views/shared/_single-footer.html.haml
+++ b/app/views/shared/_single-footer.html.haml
@@ -1,13 +1,13 @@
-%footer{class:"single-footer"}
-  %ul{class:"single-footer__menu"}
-    %li{class:"single-footer__menu__privacy"} 
+%footer.single-footer
+  %ul.single-footer__menu
+    %li.single-footer__menu__privacy
       = link_to "プライバシーポリシー", src: "#"
-    %li{class:"single-footer__menu__terms"}
+    %li.single-footer__menu__terms
       = link_to "メルカリ利用規約", src: "#"
-    %li{class:"single-footer__menu__notation"}
+    %li.single-footer__menu__notation
       = link_to "特定商取引に関する表記", src: "#"
   .single-footer__logo
     = link_to root_path do
       = image_tag 'logo-gray.svg', height:'65px'
-  .single-footer__small-text 
+  .single-footer__small-text
     %small © 2019 Mercari

--- a/app/views/shared/_single-header.html.haml
+++ b/app/views/shared/_single-header.html.haml
@@ -1,3 +1,3 @@
-%header{class:"single-header"}
+%header.single-header
   =link_to root_path,class:"single-header__logo" do
     = image_tag 'logo.svg', height:'49px'

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -9,7 +9,7 @@
             .mail-registration__left
               .icon-envelope
             .mail-registration__right
-              = link_to "メールアドレスで登録", src:"#"
+              = link_to "メールアドレスで登録", {controller:"users",action:"new",url:"registration"}
           .facebook-registration
             .facebook-registration__left
               .icon-facebook-square

--- a/app/views/users/signup/address.html.haml
+++ b/app/views/users/signup/address.html.haml
@@ -1,24 +1,24 @@
 .single-wrapper
-  %header{class:"single-header-flex"}
+  %header.single-header-flex
     .single-header-flex__left
       =link_to root_path do
         = image_tag 'logo.svg', height:'49px'
-    %nav{class:"single-header-flex__right"}
-      %ol{class:"progress-bar"}
-        %li{class:"progress-bar__progress--through"}
-          %p{class:"progress-bar__progress__text"} 会員情報
+    %nav.single-header-flex__right
+      %ol.progress-bar
+        %li.progress-bar__progress--through
+          %p.progress-bar__progress__text 会員情報
           .progress-bar__progress__status
-        %li{class:"progress-bar__progress--through"}
-        %p{class:"progress-bar__progress__text"} 電話番号認証
+        %li.progress-bar__progress--through
+          %p.progress-bar__progress__text 電話番号認証
           .progress-bar__progress__status
-        %li{class:"progress-bar__progress--active"}
-          %p{class:"progress-bar__progress__text"} お届け先住所入力
+        %li.progress-bar__progress--active
+          %p.progress-bar__progress__text お届け先住所入力
           .progress-bar__progress__status
-        %li{class:"progress-bar__progress"}
-          %p{class:"progress-bar__progress__text"} 支払い方法
+        %li.progress-bar__progress
+          %p.progress-bar__progress__text 支払い方法
           .progress-bar__progress__status
-        %li{class:"progress-bar__progress"}
-          %p{class:"progress-bar__progress__text"} 完了
+        %li.progress-bar__progress
+          %p.progress-bar__progress__text 完了
           .progress-bar__progress__status
   .single-container
     .registration

--- a/app/views/users/signup/address.html.haml
+++ b/app/views/users/signup/address.html.haml
@@ -1,0 +1,60 @@
+.single-wrapper
+  %header{class:"single-header-flex"}
+    .single-header-flex__left
+      =link_to root_path do
+        = image_tag 'logo.svg', height:'49px'
+    %nav{class:"single-header-flex__right"}
+      %ol{class:"progress-bar"}
+        %li{class:"progress-bar__progress--through"}
+          %p{class:"progress-bar__progress__text"} 会員情報
+          .progress-bar__progress__status
+        %li{class:"progress-bar__progress--through"}
+        %p{class:"progress-bar__progress__text"} 電話番号認証
+          .progress-bar__progress__status
+        %li{class:"progress-bar__progress--active"}
+          %p{class:"progress-bar__progress__text"} お届け先住所入力
+          .progress-bar__progress__status
+        %li{class:"progress-bar__progress"}
+          %p{class:"progress-bar__progress__text"} 支払い方法
+          .progress-bar__progress__status
+        %li{class:"progress-bar__progress"}
+          %p{class:"progress-bar__progress__text"} 完了
+          .progress-bar__progress__status
+  .single-container
+    .registration
+      .panel
+        .panel__head お届け先住所入力
+        .panel__inner
+          = form_for(@user,url: {controller: "users", action: "new", url: "card"}, html: {method: 'GET'})  do |f|
+            - if @user.errors.any?
+              - @user.errors.full_messages.each do |message|
+                = message
+            .content
+              .form-group
+                = f.label "郵便番号（ハイフンなし）", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.text_field :postal_code, class:"form-group__input", placeholder: "例) 1234567"
+              .form-group
+                = f.label "都道府県", class:"form-group__label"
+                %span.form-group__require 必須
+                .form-group__prefecture-select-wrap
+                  = f.select :prefecture, User.prefectures.keys, {include_blank: true}
+                  .icon-chevron-bottom
+              .form-group
+                = f.label "市区町村", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.text_field :city, class:"form-group__input", placeholder: "例) 横浜市緑区"
+              .form-group
+                = f.label "番地", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.text_field :address, class:"form-group__input", placeholder: "例) 青山1-1-1"
+              .form-group
+                = f.label "建物名", class:"form-group__label"
+                %span.form-group__optional 任意
+                = f.text_field :building, class:"form-group__input", placeholder: "例) 柏ビル103"
+              .form-group
+                = f.label "電話", class:"form-group__label"
+                %span.form-group__optional 任意
+                = f.text_field :phone, class:"form-group__input", placeholder: "例) 09012345678"
+              = f.submit "次へ進む", class:"registration-next-btn"
+  = render partial: "/shared/single-footer"

--- a/app/views/users/signup/card.html.haml
+++ b/app/views/users/signup/card.html.haml
@@ -1,0 +1,57 @@
+.single-wrapper
+  %header{class:"single-header-flex"}
+    .single-header-flex__left
+      =link_to root_path do
+        = image_tag 'logo.svg', height:'49px'
+    %nav{class:"single-header-flex__right"}
+      %ol{class:"progress-bar"}
+        %li{class:"progress-bar__progress--through"}
+          %p{class:"progress-bar__progress__text"} 会員情報
+          .progress-bar__progress__status
+        %li{class:"progress-bar__progress--through"}
+          %p{class:"progress-bar__progress__text"} 電話番号認証
+          .progress-bar__progress__status
+        %li{class:"progress-bar__progress--through"}
+          %p{class:"progress-bar__progress__text"} お届け先住所入力
+          .progress-bar__progress__status
+        %li{class:"progress-bar__progress--active"}
+          %p{class:"progress-bar__progress__text"} 支払い方法
+          .progress-bar__progress__status
+        %li{class:"progress-bar__progress"}
+          %p{class:"progress-bar__progress__text"} 完了
+          .progress-bar__progress__status
+  .single-container
+    .registration
+      .panel
+        .panel__head 支払い方法
+        .panel__inner
+          = form_for(:session,url: {controller: "users", action: "new", url: "complete"}, html: {method: 'GET'})  do |f|
+            .content
+              .form-group
+                = f.label "カード番号", class:"form-group__label"
+                %span{class:"form-group__require"} 必須
+                = f.text_field :number, class:"form-group__input", placeholder: "半角数字のみ", maxlength: "16"
+                .form-group__card-logos
+                  = image_tag 'visa_logo.png', height:'20px'
+                  = image_tag 'mastercard_logo.png', height:'20px'
+                  = image_tag 'saison_logo.png', height:'20px'
+              .form-group
+                = f.label "有効期限", class:"form-group__label"
+                %span{class:"form-group__require"} 必須
+                .form-group__expiration-wrap
+                  = f.select :exp_month, [["--",""],["1","01"],["2","02"],["3","03"],["4","04"],["5","05"],["6","06"],["7","07"],["8","08"],["9","09"],["10","10"],["11","11"],["12","12"]]
+                  .icon-chevron-bottom
+                  %span 月
+                .form-group__expiration-wrap
+                  = f.select :exp_year, [["--",""],["19","2019"],["20","2020"],["21","2021"],["22","2022"],["23","2023"],["24","2024"],["25","2025"],["26","2026"],["27","2027"],["28","2028"],["29","2029"],]
+                  %span 年
+                  .icon-chevron-bottom
+              .form-group
+                = f.label "セキュリティコード", class:"form-group__label"
+                %span{class:"form-group__require"} 必須
+                = f.text_field :cvc, class:"form-group__input", placeholder: "カード背面4桁もしくは3桁の番号", maxlength: "4"
+                .form-group__card-info
+                  .icon-question-circle
+                  =link_to "カード裏面の番号とは？", src:"#", class:"icon-chevron-right"
+              = f.submit "次へ進む", class:"registration-next-btn"
+  = render partial: "/shared/single-footer"

--- a/app/views/users/signup/card.html.haml
+++ b/app/views/users/signup/card.html.haml
@@ -1,24 +1,24 @@
 .single-wrapper
-  %header{class:"single-header-flex"}
+  %header.single-header-flex
     .single-header-flex__left
       =link_to root_path do
         = image_tag 'logo.svg', height:'49px'
-    %nav{class:"single-header-flex__right"}
-      %ol{class:"progress-bar"}
-        %li{class:"progress-bar__progress--through"}
-          %p{class:"progress-bar__progress__text"} 会員情報
+    %nav.single-header-flex__right
+      %ol.progress-bar
+        %li.progress-bar__progress--through
+          %p.progress-bar__progress__text 会員情報
           .progress-bar__progress__status
-        %li{class:"progress-bar__progress--through"}
-          %p{class:"progress-bar__progress__text"} 電話番号認証
+        %li.progress-bar__progress--through
+          %p.progress-bar__progress__text 電話番号認証
           .progress-bar__progress__status
-        %li{class:"progress-bar__progress--through"}
-          %p{class:"progress-bar__progress__text"} お届け先住所入力
+        %li.progress-bar__progress--through
+          %p.progress-bar__progress__text お届け先住所入力
           .progress-bar__progress__status
-        %li{class:"progress-bar__progress--active"}
-          %p{class:"progress-bar__progress__text"} 支払い方法
+        %li.progress-bar__progress--active
+          %p.progress-bar__progress__text 支払い方法
           .progress-bar__progress__status
-        %li{class:"progress-bar__progress"}
-          %p{class:"progress-bar__progress__text"} 完了
+        %li.progress-bar__progress
+          %p.progress-bar__progress__text 完了
           .progress-bar__progress__status
   .single-container
     .registration
@@ -29,7 +29,7 @@
             .content
               .form-group
                 = f.label "カード番号", class:"form-group__label"
-                %span{class:"form-group__require"} 必須
+                %span.form-group__require 必須
                 = f.text_field :number, class:"form-group__input", placeholder: "半角数字のみ", maxlength: "16"
                 .form-group__card-logos
                   = image_tag 'visa_logo.png', height:'20px'
@@ -37,7 +37,7 @@
                   = image_tag 'saison_logo.png', height:'20px'
               .form-group
                 = f.label "有効期限", class:"form-group__label"
-                %span{class:"form-group__require"} 必須
+                %span.form-group__require 必須
                 .form-group__expiration-wrap
                   = f.select :exp_month, [["--",""],["1","01"],["2","02"],["3","03"],["4","04"],["5","05"],["6","06"],["7","07"],["8","08"],["9","09"],["10","10"],["11","11"],["12","12"]]
                   .icon-chevron-bottom
@@ -48,7 +48,7 @@
                   .icon-chevron-bottom
               .form-group
                 = f.label "セキュリティコード", class:"form-group__label"
-                %span{class:"form-group__require"} 必須
+                %span.form-group__require 必須
                 = f.text_field :cvc, class:"form-group__input", placeholder: "カード背面4桁もしくは3桁の番号", maxlength: "4"
                 .form-group__card-info
                   .icon-question-circle

--- a/app/views/users/signup/complete.html.haml
+++ b/app/views/users/signup/complete.html.haml
@@ -1,0 +1,35 @@
+.single-wrapper
+  %header.single-header-flex
+    .single-header-flex__left
+      =link_to root_path do
+        = image_tag 'logo.svg', height:'49px'
+    %nav.single-header-flex__right
+      %ol.progress-bar
+        %li.progress-bar__progress--through
+          %p.progress-bar__progress__text 会員情報
+          .progress-bar__progress__status
+        %li.progress-bar__progress--through
+          %p.progress-bar__progress__text 電話番号認証
+          .progress-bar__progress__status
+        %li.progress-bar__progress--through
+          %p.progress-bar__progress__text お届け先住所入力
+          .progress-bar__progress__status
+        %li.progress-bar__progress--through
+          %p.progress-bar__progress__text 支払い方法
+          .progress-bar__progress__status
+        %li.progress-bar__progress--active
+          %p.progress-bar__progress__text 完了
+          .progress-bar__progress__status
+  .single-container
+    .registration
+      .panel
+        .panel__head 会員登録完了
+        .panel__inner
+          .content
+            .form-group
+              %p.form-group__center-text
+                ありがとうございます。
+                %br
+                会員登録が完了しました。
+            = link_to "登録完了",root_path, class:"registration-next-btn"
+  = render partial: "/shared/single-footer"

--- a/app/views/users/signup/registration.html.haml
+++ b/app/views/users/signup/registration.html.haml
@@ -1,0 +1,91 @@
+.single-wrapper
+  %header.single-header-flex
+    .single-header-flex__left
+      =link_to root_path do
+        = image_tag 'logo.svg', height:'49px'
+    %nav.single-header-flex__right
+      %ol.progress-bar
+        %li.progress-bar__progress--active
+          %p.progress-bar__progress__text 会員情報
+          .progress-bar__progress__status
+        %li.progress-bar__progress
+          %p.progress-bar__progress__text 電話番号認証
+          .progress-bar__progress__status
+        %li.progress-bar__progress
+          %p.progress-bar__progress__text お届け先住所入力
+          .progress-bar__progress__status
+        %li.progress-bar__progress
+          %p.progress-bar__progress__text 支払い方法
+          .progress-bar__progress__status
+        %li.progress-bar__progress
+          %p.progress-bar__progress__text 完了
+          .progress-bar__progress__status
+  .single-container
+    .registration
+      .panel
+        .panel__head 会員情報入力
+        .panel__inner
+          = form_for(@user,url: {controller: "users", action: "new", url: "address"}, html: {method: 'GET'}) do |f|
+            - if @user.errors.any?
+              - @user.errors.full_messages.each do |message|
+                = message
+            .content
+              .form-group
+                = f.label "ニックネーム", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.text_field :name, class:"form-group__input", placeholder: "例) メルカリ太郎"
+              .form-group
+                = f.label "メールアドレス", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.text_field :email, class:"form-group__input", placeholder: "PC・携帯どちらでも可"
+              .form-group
+                = f.label "パスワード", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.password_field :password, class:"form-group__input", placeholder: "6文字以上"
+              .form-group
+                = f.label "パスワード (確認)", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.password_field :password_confirmation, class:"form-group__input", placeholder: "6文字以上"
+              .form-group
+                %h3.form-group__head 本人確認
+                %p.form-group__left-text 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+              .form-group
+                = f.label "姓 (全角)", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.text_field :last_name, class:"form-group__input", placeholder: "例) 山田"
+              .form-group
+                = f.label "名 (全角)", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.text_field :first_name, class:"form-group__input", placeholder: "例) 彩"
+              .form-group
+                = f.label "姓カナ (全角)", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.text_field :last_name_kana, class:"form-group__input", placeholder: "例) ヤマダ"
+              .form-group
+                = f.label "名カナ (全角) ", class:"form-group__label"
+                %span.form-group__require 必須
+                = f.text_field :first_name_kana, class:"form-group__input", placeholder: "例) アヤ"
+              .form-group
+                = f.label "生年月日", class:"form-group__label"
+                %span.form-group__require 必須
+                .form-group__birthday-select-wrap
+                  .form-group__birthday-select-wrap__left
+                    = raw sprintf(f.date_select(:birthday, use_month_numbers: true,start_year: 1900,end_year:(Time.now.year),include_blank: true,date_separator: '%s'), '年', '月') + '日'
+                  .form-group__birthday-select-wrap__right
+                    .chevron-box
+                      .icon-chevron-bottom
+                    .chevron-box
+                      .icon-chevron-bottom
+                    .chevron-box
+                      .icon-chevron-bottom
+                .form-info-text ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+                .form-group
+                  %p.form-group__center-text
+                    「次へ進む」のボタンを押すことにより、
+                    %a{href:"#"} 利用規約
+                    に同意したものとみなします
+                = f.submit "次へ進む", class:"registration-next-btn"
+                .form-group
+                  .form-group__info-link
+                    =link_to "本人情報の登録について", src:"#", class:"icon-chevron-right"
+  = render partial: "/shared/single-footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,11 @@ Rails.application.routes.draw do
   get 'edit' => 'users#edit'
   # ルーティングは追って検討する
 
-  get 'users/signup/:url', controller: 'users', action: 'new'
-
-  resources :users, only: [:show, :new]
+  resources :users, only: [:show, :new] do
+    collection do
+      get 'signup/:url',action: 'new'
+    end
+  end
   resources :items, only: [:index, :show, :new, :create] do
     resources :categories, only: [:search]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   get 'edit' => 'users#edit'
   # ルーティングは追って検討する
 
+  get 'users/signup/:url', controller: 'users', action: 'new'
+
   resources :users, only: [:show, :new]
   resources :items, only: [:index, :show, :new, :create] do
     resources :categories, only: [:search]


### PR DESCRIPTION
# WHAT
ユーザー新規登録をウィザードフォームにて行えるようにする。

＊レビュワーの方へ
申し訳ありません、昨日[こちらのプルリクエスト](https://github.com/Akinori0123/freemarket_sample_50teama/pull/81)にて同じ作業をしていましたが、masterへの不要な変更が`git revert`を用いても打ち消すことができず、またコンフリクトも大量に発生してしまったため、作業効率を考えて新しいプルリクエストを作らせていただきました。
昨日いただいたレビューと、その返信は以下の通りです。

<img width="656" alt="スクリーンショット 2019-05-16 13 14 33" src="https://user-images.githubusercontent.com/49008705/57826076-a0745600-77dc-11e9-86f8-66e33765d4fa.png">
<img width="656" alt="スクリーンショット 2019-05-16 13 14 40" src="https://user-images.githubusercontent.com/49008705/57826079-a5d1a080-77dc-11e9-8cf7-3d0fd8483c17.png">
<img width="654" alt="スクリーンショット 2019-05-16 13 14 47" src="https://user-images.githubusercontent.com/49008705/57826081-a79b6400-77dc-11e9-8ef4-fccdf5f6997e.png">

レビュー内容を反映させた修正はcorrect-hamlコミットとcorrect-routeコミットの二つです。ご確認のほどよろしくお願いいたします。

# WHY
ユーザー機能を実装するため。