### PR TITLE
商品一覧表示の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
 
   def index # トップページ、アイテムをカテゴリー別に最新投稿順番に
-    @items = Item.all.order(id: "DESC")
+    @items = Item.all.order(id: "DESC").limit(4)
   end
 
   def new


### PR DESCRIPTION
# WHAT
トップページの商品一覧表示の際に登録されている商品全てが表示されてしまうのを修正

# WHY
トップページが縦に長くなるのを防ぐため