### PR TITLE
userモデルにfacebook認証とpayjpのためのカラムを追加

### DIFF
--- a/db/migrate/20190518033611_add_omniauth_to_users.rb
+++ b/db/migrate/20190518033611_add_omniauth_to_users.rb
@@ -1,0 +1,7 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+    add_column :users, :payjp_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_15_112929) do
+ActiveRecord::Schema.define(version: 2019_05_18_033611) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -78,23 +78,26 @@ ActiveRecord::Schema.define(version: 2019_05_15_112929) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name", limit: 20, null: false
-    t.string "first_name", null: false
-    t.string "last_name", null: false
-    t.string "first_name_kana", null: false
-    t.string "last_name_kana", null: false
+    t.string "name", limit: 20, default: "", null: false
+    t.string "first_name", default: "", null: false
+    t.string "last_name", default: "", null: false
+    t.string "first_name_kana", default: "", null: false
+    t.string "last_name_kana", default: "", null: false
     t.integer "postal_code", null: false
     t.integer "prefecture", null: false
-    t.string "city", null: false
-    t.string "address", null: false
-    t.string "building"
+    t.string "city", default: "", null: false
+    t.string "address", default: "", null: false
+    t.string "building", default: "", null: false
     t.string "phone", null: false
     t.date "birthday", null: false
-    t.integer "money", default: 0, null: false
+    t.integer "money", default: 0, null: false, unsigned: true
     t.integer "point", default: 0, null: false
     t.integer "seller_id", null: false
     t.integer "buyer_id", null: false
     t.text "profile"
+    t.string "provider"
+    t.string "uid"
+    t.string "payjp_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# WHAT
userモデルに以下のカラムを追加する
・string型のproviderカラム（facebook,google認証のため）
・string型のuidカラム（facebook,google認証のため）
・string型のpayjp_idカラム（payjpのため）