### PR TITLE
UserItemテーブルのダミー追加

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,19 +78,19 @@ ActiveRecord::Schema.define(version: 2019_05_18_033611) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name", limit: 20, default: "", null: false
-    t.string "first_name", default: "", null: false
-    t.string "last_name", default: "", null: false
-    t.string "first_name_kana", default: "", null: false
-    t.string "last_name_kana", default: "", null: false
+    t.string "name", limit: 20, null: false
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "first_name_kana", null: false
+    t.string "last_name_kana", null: false
     t.integer "postal_code", null: false
     t.integer "prefecture", null: false
-    t.string "city", default: "", null: false
-    t.string "address", default: "", null: false
-    t.string "building", default: "", null: false
+    t.string "city", null: false
+    t.string "address", null: false
+    t.string "building"
     t.string "phone", null: false
     t.date "birthday", null: false
-    t.integer "money", default: 0, null: false, unsigned: true
+    t.integer "money", default: 0, null: false
     t.integer "point", default: 0, null: false
     t.integer "seller_id", null: false
     t.integer "buyer_id", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,3 +13,9 @@ end
 60.times do |num|
   Item.create(name: "お買い得セット#{num + 1}", condition: 0, delivery_fee: 1000, delivery_days: 0, price: (num + 1) * 1000)
 end
+
+60.times do |num|
+  UserItem.create(user_id: (num + 1), item_id: num * 3 + 1)
+  UserItem.create(user_id: (num + 1), item_id: num * 3 + 2)
+  UserItem.create(user_id: (num + 1), item_id: num * 3 + 3)
+end


### PR DESCRIPTION
# What?
UserItemテーブルのダミー追加

# Why?
既存ダミーデータのUserと出品Itemのデータを結びつけて利用できるようにするため