### PR TITLE
サーバーデプロイエラー対処中

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
     erb2haml (0.1.5)
@@ -145,6 +147,8 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -187,6 +191,7 @@ GEM
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -209,6 +214,8 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
     orm_adapter (0.5.0)
+    payjp (0.0.6)
+      rest-client (~> 2.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -260,6 +267,10 @@ GEM
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     ruby_dep (1.5.0)
     ruby_parser (3.13.1)
       sexp_processor (~> 4.9)
@@ -305,6 +316,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -351,6 +365,7 @@ DEPENDENCIES
   omniauth
   omniauth-facebook
   omniauth-google-oauth2
+  payjp
   pry-byebug
   pry-doc
   pry-rails


### PR DESCRIPTION
# What?
自分のローカルで生成したgemfile.lockをアップロードしてみる
実質的に前回の対処前に変更を戻すだけ
https://github.com/Akinori0123/freemarket_sample_50teama/pull/135
でのgemfile.lock変更と特に変わりないことを確認済。
おそらくこの変更によってエラー解決することはないと予測。

# Why?
デプロイプロセスのbundle install時のエラーが継続しているが
bundle installしてからgemfile.lock作ってアップロードしろ的なことを言われているため。
また現在の状態のままでいるとpullした時に必ずgemfile.lockを各ローカルで変更することになり
pushファイルに含まれてしまうため。