### PR TITLE
新規ユーザー登録画面のエラー解消

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,7 @@ class Item < ApplicationRecord
     tottori: 31, shimane: 32, okayama: 33, hiroshima: 34, yamaguchi: 35,
     tokushima: 36, kagawa: 37, ehime: 38, kochi: 39,
     fukuoka: 40, saga: 41, nagasaki: 42, kumamoto: 43, oita: 44, miyazaki: 45, kagoshima: 46, okinawa: 47,
-    undicided: 99
+    undicided: 48
   }, _prefix: true
 
   enum condition: {
@@ -22,11 +22,11 @@ class Item < ApplicationRecord
   }
 
   enum delivery_fee: {
-    exhibitr_barden: 2, buyer_barden: 1
+    exhibitr_barden: 1, buyer_barden: 2
   }
 
   enum ship_by: {
-    undicided: 5, mercari: 14, u_mail: 6, letter_pack: 8, usealy: 9, yamato: 10, u_pack: 11, click_post: 13, u_packet: 7
+    undicided: 1, mercari: 2, u_mail: 3, letter_pack: 4, usealy: 5, yamato: 6, u_pack: 7, click_post: 8, u_packet: 9
   }, _prefix: true
 
   enum delivery_days: {

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,28 @@
 ja:
+  date:
+    formats:
+      default: "%Y/%m/%d"
+      short: "%m/%d"
+      long: "%Y年%m月%d日(%a)"
+
+    day_names: [日曜日, 月曜日, 火曜日, 水曜日, 木曜日, 金曜日, 土曜日]
+    abbr_day_names: [日, 月, 火, 水, 木, 金, 土]
+
+    month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+    abbr_month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+
+    order:
+      - :year
+      - :month
+      - :day
+
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      short: "%y/%m/%d %H:%M"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %Z"
+    am: "午前"
+    pm: "午後"
   enums:
     user:
       prefecture:


### PR DESCRIPTION
# What?
**本件についてローカルでエラー解消、viewの表示を確認。**
**一連のフォーム上でユーザー登録完了し、そのレコード作成を確認。**

新規ユーザー登録画面で以下のエラー
[undefined method `map' for "translation missing: ja.date.order":String]

### date_orderに対応した記述を追加
config/locales/ja.yml

当該エラーはja: date: order:であるが、
以下の記事を参考に関係の近い部分を一式取り入れている。
https://qiita.com/wada811/items/e26692ca3dea4e03ba30

### enumリストの値をリストの並び順に昇順の連続した数値に振り直し。
本件の日本語変換の元となるenumのフォームでの数値の扱いをわかりやすくするため。
本エラーと直接の因果関係はないが、将来的な開発しやすさ、バグの発生を防ぐ目的での変更。
app/models/item.rb

# Why?
config/locals/以下にある特定のymlファイルは
ざっくりいうとrailsで使われる特定のシンボルに対する対応文字列の辞書みたいなもの。

おそらく
gem enum_helpの追加に伴って、ja.ymlを参照するように設定したのだが、
rails既存機能のうちen.ymlの辞書を参照して動作していた機能までもが
その設定情報のもとja.ymlを参照するようになった。
しかし、参照するべき辞書がja.yml内に存在しない事でエラーとなっていたと考えられる。

# 備考
そもそもこのja.yml追加時点でローカル動作からレコード作成まで確認していたのに
なぜ今になって若干関係ない部分でこのエラーが出てきたのかは不明。

つまり、本件の周辺範囲でのエラー解消は確認できたものの、
(あまり頻繁な例とは考えにくいが)今後他の新たなrailsヘルパーメソッドを利用した場合などに、
同様のエラー発生の可能性は排除しきれない。