### PR TITLE
SNSアカウントによる新規登録・ログイン機能の復活

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,14 @@ class User < ApplicationRecord
     fukuoka: 40, saga: 41, nagasaki: 42, kumamoto: 43, oita: 44, miyazaki: 45, kagoshima: 46, okinawa: 47
   }, _prefix: true
 
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.email = auth.info.email
+      user.password = Devise.friendly_token[0,20]
+      user.name = auth.info.name
+    end
+  end
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :omniauthable,


### PR DESCRIPTION
# WHAT
[#130](https://github.com/Akinori0123/freemarket_sample_50teama/pull/130)により消えたuserモデルのself.from_omniauthメソッドを復活させる

# WHY
SNSアカウントによるログインを可能にするため