### PR TITLE
アップローダ修正（追記）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 
 /public/assets
 /public/myfiles
+/public/uploads
 .byebug_history
 
 /test.coffee

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,6 +5,8 @@ class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   has_many :categories
 
+  mount_uploader :image, ImageUploader
+
   enum ship_from: {
     hokkaido: 1, aomori: 2, iwate: 3, miyagi: 4, akita: 5, yamagata: 6, fukushima: 7,
     ibaraki: 8, tochigi: 9, gunma: 10, saitama: 11, chiba: 12, tokyo: 13, kanagawa: 14,


### PR DESCRIPTION
# What?
### アップローダ指定ヘルパーメソッドの追記
app/models/item.rb
### 画像アップロード先フォルダのgitignore追記
.gitignore

※carrierwaveのアップロード先設定により、従前のseedを実行すると
新たにpublic/uploads/以下にアップロードされた画像ファイルが作成されます。


# Why?
そもそも各環境においてcarrierwaveでのアップロードを経由した画像seedを作るには
アップローダの指定をするヘルパーメソッドの記述が必要、この点で
チームの各ローカルと、商品新規登録フォームでの動作試験をしていた端末では原因が別でした。

mout_uploaders :image, ItemUploader
というように、ヘルパーメソッドが間違った複数形をしていた
あるいはヘルパーメソッドそのものがなかったということで、carrierwaveアップローダが正常に動作できない環境にあった。
ただし、ここではヘルパーメソッドそのものが未定義、
というようなエラーはなかったことから、この記述そのものがおかしい、あるいは
記述そのものがないことでseedのopen()メソッドがエラーを起こして止まるわけではない様子。
何れにしても、単数形複数形には厳格な意味があるので、コピペソースに含まれている場合かなり注意するべき項目である。