### PR TITLE
カラム名編集によるview_enum崩れの解消

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,7 +5,7 @@ class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   has_many :categories
 
-  enum ship_from: {
+  enum delivery_prefecture: {
     hokkaido: 1, aomori: 2, iwate: 3, miyagi: 4, akita: 5, yamagata: 6, fukushima: 7,
     ibaraki: 8, tochigi: 9, gunma: 10, saitama: 11, chiba: 12, tokyo: 13, kanagawa: 14,
     nigata: 15, toyama: 16, ishikawa: 17, fukui: 18, yamanashi: 19, nagano: 20,
@@ -21,15 +21,15 @@ class Item < ApplicationRecord
     new_one: 1, almost_new: 2, no_scratchies: 3, little_worn: 4, worn: 5, bad: 6
   }
 
-  enum delivery_fee: {
+  enum delivery_cost: {
     exhibitr_barden: 1, buyer_barden: 2
   }
 
-  enum ship_by: {
+  enum delivery_method: {
     undicided: 1, mercari: 2, u_mail: 3, letter_pack: 4, usealy: 5, yamato: 6, u_pack: 7, click_post: 8, u_packet: 9
   }, _prefix: true
 
-  enum delivery_days: {
+  enum delivery_day: {
     a_day: 1, a_couple_of_days: 2, a_week: 3
   }
 end

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -13,7 +13,7 @@
             %p.item-info__price
               ="¥#{@item.price}"
               %span.item-info__price__shipping
-                = @item.delivery_fee
+                = @item.delivery_cost
                 -# ポイントがある場合とない場合で表示が切り替わります。余裕があれば追加
                 -# %ul.buy-accordion.not-have
                 -#   %li.buy-accordion__inner
@@ -44,7 +44,7 @@
                 =current_user.name
 
               %p.link-to-change.icon-arrow-r
-                =link_to "変更する","/users/mypage/identification"
+                =link_to "変更する", edit_path(url:"identification")
                 
           -# 支払い情報がnillだとグレーのボタンとなり購入できないが、とりあえず無視する
           %hr.line
@@ -56,6 +56,6 @@
               = "#{@card.exp_month} / #{@card.exp_year}"
 
             %p.link-to-change.icon-arrow-r
-              =link_to "変更する", new_card_path
+              =link_to "変更する", user_card_path(user_id:'mypage',id:'show')
 
   = render 'shared/single-footer'

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -56,6 +56,7 @@
               = "#{@card.exp_month} / #{@card.exp_year}"
 
             %p.link-to-change.icon-arrow-r
-              =link_to "変更する", user_card_path(user_id:'mypage',id:'show')
+              -# =link_to "変更する", user_card_path(user_id:'mypage',id:'show')
+              =link_to "変更する", card_path(id:current_user.id)
 
   = render 'shared/single-footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -14,7 +14,7 @@
             = "￥#{@item.price}"
             %span.item-info__price__tax (税込)
             %span.item-info__price__sipping
-            = @item.delivery_fee
+            = @item.delivery_cost
         .sales-message
           - if user_signed_in?
             ="売上金#{current_user.money}円をお持ちです"
@@ -54,27 +54,27 @@
           %tr
             %th 配送料の負担
             %td
-              = @item.delivery_fee
+              = @item.delivery_cost
           %tr
             %th 配送の方法
             %td
-              = @item.ship_by
+              = @item.delivery_method
           %tr
             %th 配送元地域
             %td
               %p.detail_link
-                =link_to "#{@item.ship_from}", '#'
+                =link_to "#{@item.delivery_prefecture}", '#'
           %tr
             %th 発送日の目安
             %td
-              =@item.delivery_days
+              =@item.delivery_day
       .item-info
         .item-info__price
           %p
             = "￥#{@item.price}"
             %span.item-info__price__tax (税込)
             %span.item-info__price__sipping
-              = @item.delivery_fee
+              = @item.delivery_cost
 
         - if user_signed_in?
           .sales-message


### PR DESCRIPTION
# What
カラム名編集によるview_enum崩れの解消

SSIA
https://blog.sixapart.jp/2016-10/lgtm-github.html

表示確認済みです。

# Why
カラムを変更したことでviewが開けない。enumが適切に表示させられないバグの解消