### PR TITLE
リンクとリンクボタンのscssの修正

### DIFF
--- a/app/assets/stylesheets/shared/_mypage-nav.scss
+++ b/app/assets/stylesheets/shared/_mypage-nav.scss
@@ -8,11 +8,11 @@
     position: relative;
     display: block;
     min-height: 48px;
-    padding: 16px;
     background: $white;
     font-size: 14px;
     color: $gray-lv4;
     border-bottom: solid 1px $gray-lv1;
+    line-height: 48px;
     &:hover{
       opacity: 0.8;
       .icon-arrow-r::after{
@@ -45,6 +45,10 @@
       position: absolute;
       right:20px;
       }
+    }
+    a {
+      display: block;
+      padding: 0 16px;
     }
   }
   &__head{

--- a/app/views/shared/_items-box.html.haml
+++ b/app/views/shared/_items-box.html.haml
@@ -4,12 +4,12 @@
       = link_to item_path(id: item.id) do
         = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item1"), class: '.item-box__photo'
         -# = image_tag ("#"), alt: #{'出品タイトル'}, class: #{'ブランド名'} バックエンドができればこちらに差し替え
-      .item-box__info
-        %h3.item-box__info__name
-          = item.name
-        .item-box__bottom
-          %p.item-box__bottom__price
-            ¥
-            = item.price
-          %p.item-box__bottom__like.icon-like 1
-          %p.item-box__bottom__tax (税込)
+        .item-box__info
+          %h3.item-box__info__name
+            = item.name
+          .item-box__bottom
+            %p.item-box__bottom__price
+              ¥
+              = item.price
+            %p.item-box__bottom__like.icon-like 1
+            %p.item-box__bottom__tax (税込)

--- a/app/views/shared/_mypage-nav.html.haml
+++ b/app/views/shared/_mypage-nav.html.haml
@@ -57,7 +57,7 @@
   %ul
     %li.mypage-nav__list
       .mypage-nav__list__inner.icon-arrow-r
-      = link_to "プロフィール", {controller:"users",action:"edit",url:"profile"}
+      = link_to "プロフィール", edit_path(url: 'profile')
     %li.mypage-nav__list
       .mypage-nav__list__inner.icon-arrow-r
       =link_to '発送元・お届け先住所変更','#'
@@ -69,10 +69,10 @@
       =link_to 'メール/パスワード','#'
     %li.mypage-nav__list
       .mypage-nav__list__inner.icon-arrow-r
-      = link_to "本人情報", {controller:"users",action:"edit",url:"identification"}
+      = link_to "本人情報", edit_path(url: 'identification')
     %li.mypage-nav__list
       .mypage-nav__list__inner.icon-arrow-r
       =link_to '電話番号の確認','#'
     %li.mypage-nav__list.mypage-nav__current-page
       .mypage-nav__list__inner.icon-arrow-r
-      = link_to "ログアウト", {controller:"users",action:"edit",url:"logout"}
+      = link_to "ログアウト", edit_path(url: 'logout')


### PR DESCRIPTION
# WHAT
各コミットで、以下の修正を行いました
・mypage-navのリンクをprefixで記述
・mypage-navのリンクの範囲をボタン全体に広げる
・item-boxのリンクの範囲が画像のみだったのをitem-box全体に広げる

# WHY
リンクボタンをクリックしやすくするようにするため