### PR TITLE
商品詳細ページカルーセルの実装

### DIFF
--- a/app/assets/javascripts/carousel.js
+++ b/app/assets/javascripts/carousel.js
@@ -1,6 +1,31 @@
+//----------------------------------------top page
 $(document).on('turbolinks:load', function(){
   $('.slick').slick({
     autoplay:true,
     dots:true,
+  });
+
+
+//----------------------------------------商品詳細ページ
+
+  $('.slider').slick({
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    arrows: false,
+    fade: true,
+    asNavFor: '.thumb'
+  });
+  $('.thumb').slick({
+    slidesToShow: 5,
+    slidesToScroll: 1,
+    asNavFor: '.slider',
+    dots: false,
+    centerMode: true,
+    focusOnSelect: true
+  });
+
+  $(".thumb__list").on('click', function(){
+    $(".thumb__list").css("opacity","0.7");
+    $(this).css("opacity","1");
   });
 });

--- a/app/assets/stylesheets/carousel/slick-theme.scss
+++ b/app/assets/stylesheets/carousel/slick-theme.scss
@@ -15,8 +15,10 @@ $slick-dot-color: black !default;
 $slick-dot-color-active: $slick-dot-color !default;
 $slick-prev-character: "\2190" !default;
 $slick-next-character: "\2192" !default;
-$slick-dot-character: "\f111" !default;
-$slick-dot-size:  8px !default;
+$slick-dot-character: "\2022" !default;
+$slick-dot-character2: "\f111";
+$slick-dot-size: 6px !default;
+$slick-dot-size2:  8px;
 $slick-opacity-default: 0.75 !default;
 $slick-opacity-on-hover: 1 !default;
 $slick-opacity-not-active: 0.8 !default;
@@ -38,23 +40,24 @@ $slick-opacity-not-active: 0.8 !default;
         @return url($slick-font-path + $url);
     }
 }
+//--------------------------------------default
 
 /* Slider */
 
 .slick-list {
-    .slick-loading & {
-        background: #fff slick-image-url("ajax-loader.gif") center center no-repeat;
-    }
+  .slick-loading & {
+      background: #fff slick-image-url("ajax-loader.gif") center center no-repeat;
+  }
 }
 
 /* Icons */
 @if $slick-font-family == "slick" {
   @font-face {
-    font-family: "slick";
-    src: slick-font-url("slick.eot");
-    // src: slick-font-url("slick.eot?#iefix") format("embedded-opentype"), slick-font-url("slick.woff") format("woff"), slick-font-url("slick.ttf") format("truetype"), slick-font-url("slick.svg#slick") format("svg");
-    font-weight: normal;
-    font-style: normal;
+      font-family: "slick";
+      src: slick-font-url("slick.eot");
+      src: slick-font-url("slick.eot?#iefix") format("embedded-opentype"), slick-font-url("slick.woff") format("woff"), slick-font-url("slick.ttf") format("truetype"), slick-font-url("slick.svg#slick") format("svg");
+      font-weight: normal;
+      font-style: normal;
   }
 }
 
@@ -62,44 +65,209 @@ $slick-opacity-not-active: 0.8 !default;
 
 .slick-prev,
 .slick-next {
-    position: absolute;
-    display: block;
-    height: 20px;
-    width: 20px;
-    line-height: 0px;
-    font-size: 20px;
-    cursor: pointer;
-    background: transparent;
-    color: transparent;
-    top: 50%;
-    -webkit-transform: translate(0, -50%);
-    -ms-transform: translate(0, -50%);
-    transform: translate(0, -50%);
-    padding: 0;
-    border: none;
-    outline: none;
-    z-index:100;
-    &:hover, &:focus {
-        outline: none;
-        background: transparent;
-        color: transparent;
-        &:before {
-            opacity: $slick-opacity-on-hover;
-        }
-    }
-    &.slick-disabled:before {
-        opacity: $slick-opacity-not-active;
-    }
-    &:before {
-        font-family: $slick-font-family;
-        font-size: 20px;
-        line-height: 1;
-        color: $slick-arrow-color;
-        opacity: $slick-opacity-default;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-    }
+  position: absolute;
+  display: block;
+  height: 20px;
+  width: 20px;
+  line-height: 0px;
+  font-size: 0px;
+  cursor: pointer;
+  background: transparent;
+  color: transparent;
+  top: 50%;
+  -webkit-transform: translate(0, -50%);
+  -ms-transform: translate(0, -50%);
+  transform: translate(0, -50%);
+  padding: 0;
+  border: none;
+  outline: none;
+  &:hover, &:focus {
+      outline: none;
+      background: transparent;
+      color: transparent;
+      &:before {
+          opacity: $slick-opacity-on-hover;
+      }
+  }
+  &.slick-disabled:before {
+      opacity: $slick-opacity-not-active;
+  }
+  &:before {
+      font-family: $slick-font-family;
+      font-size: 20px;
+      line-height: 1;
+      color: $slick-arrow-color;
+      opacity: $slick-opacity-default;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+  }
 }
+
+.slick-prev {
+  left: -25px;
+  [dir="rtl"] & {
+      left: auto;
+      right: -25px;
+  }
+  &:before {
+      content: $slick-prev-character;
+      [dir="rtl"] & {
+          content: $slick-next-character;
+      }
+  }
+}
+
+.slick-next {
+  right: -25px;
+  [dir="rtl"] & {
+      left: -25px;
+      right: auto;
+  }
+  &:before {
+      content: $slick-next-character;
+      [dir="rtl"] & {
+          content: $slick-prev-character;
+      }
+  }
+}
+
+/* Dots */
+
+.slick-dotted.slick-slider {
+  margin-bottom: 30px;
+}
+
+.slick-dots {
+  position: absolute;
+  bottom: -25px;
+  list-style: none;
+  display: block;
+  text-align: center;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  li {
+      position: relative;
+      display: inline-block;
+      height: 20px;
+      width: 20px;
+      margin: 0 5px;
+      padding: 0;
+      cursor: pointer;
+      button {
+          border: 0;
+          background: transparent;
+          display: block;
+          height: 20px;
+          width: 20px;
+          outline: none;
+          line-height: 0px;
+          font-size: 0px;
+          color: transparent;
+          padding: 5px;
+          cursor: pointer;
+          &:hover, &:focus {
+              outline: none;
+              &:before {
+                  opacity: $slick-opacity-on-hover;
+              }
+          }
+          &:before {
+              position: absolute;
+              top: 0;
+              left: 0;
+              content: $slick-dot-character;
+              width: 20px;
+              height: 20px;
+              font-family: $slick-font-family;
+              font-size: $slick-dot-size;
+              line-height: 20px;
+              text-align: center;
+              color: $slick-dot-color;
+              opacity: $slick-opacity-not-active;
+              -webkit-font-smoothing: antialiased;
+              -moz-osx-font-smoothing: grayscale;
+          }
+      }
+      &.slick-active button:before {
+          color: $slick-dot-color-active;
+          opacity: $slick-opacity-default;
+      }
+  }
+}
+
+// ------------------------------------item-detail-page
+/* Slider */
+.item-detail-page{
+  .slider{
+    width: 300px;
+    height: 300px;
+    font-size: 50px;
+    // 画像が表示されるようになったらここから下の２行は消す
+    background-color: rgba(255,0,0, 0.7);
+    color: #fff;
+    &:focus{
+      outline:none;
+    }
+  }
+  .draggable{
+    padding:0px !important;
+    .thumb__list{
+      width: 60px !important;
+      height: 60px;
+      opacity: 0.7;
+      margin: 0px;
+      outline:none;
+      // 画像が表示されるようになったらここから下の２行は消す
+      background-color: rgba(0, 0,255, 0.7);
+      color: #fff;
+    }
+  }
+}
+// -----------------------------------------index page
+
+.index-page{
+
+  .slick-prev,
+  .slick-next {
+      position: absolute;
+      display: block;
+      height: 20px;
+      width: 20px;
+      line-height: 0px;
+      font-size: 20px;
+      cursor: pointer;
+      background: transparent;
+      color: transparent;
+      top: 50%;
+      -webkit-transform: translate(0, -50%);
+      -ms-transform: translate(0, -50%);
+      transform: translate(0, -50%);
+      padding: 0;
+      border: none;
+      outline: none;
+      z-index:100;
+      &:hover, &:focus {
+          outline: none;
+          background: transparent;
+          color: transparent;
+          &:before {
+              opacity: $slick-opacity-on-hover;
+          }
+      }
+      &.slick-disabled:before {
+          opacity: $slick-opacity-not-active;
+      }
+      &:before {
+          font-family: $slick-font-family;
+          font-size: 20px;
+          line-height: 1;
+          color: $slick-arrow-color;
+          opacity: $slick-opacity-default;
+          -webkit-font-smoothing: antialiased;
+          -moz-osx-font-smoothing: grayscale;
+      }
+  }
 
 .slick-prev {
   left: 30px;
@@ -176,7 +344,7 @@ $slick-opacity-not-active: 0.8 !default;
                 position: absolute;
                 top: 0;
                 left: 0;
-                content: $slick-dot-character;
+                content: $slick-dot-character2;
                 width: 20px;
                 height: 20px;
                 font-family: "Font Awesome 5 Free";
@@ -195,4 +363,5 @@ $slick-opacity-not-active: 0.8 !default;
             opacity: $slick-opacity-default;
         }
     }
+}
 }

--- a/app/assets/stylesheets/carousel/slick-theme.scss
+++ b/app/assets/stylesheets/carousel/slick-theme.scss
@@ -46,7 +46,7 @@ $slick-opacity-not-active: 0.8 !default;
 
 .slick-list {
   .slick-loading & {
-      background: #fff slick-image-url("ajax-loader.gif") center center no-repeat;
+      background: $white slick-image-url("ajax-loader.gif") center center no-repeat;
   }
 }
 

--- a/app/assets/stylesheets/carousel/slick-theme.scss
+++ b/app/assets/stylesheets/carousel/slick-theme.scss
@@ -203,24 +203,35 @@ $slick-opacity-not-active: 0.8 !default;
     width: 300px;
     height: 300px;
     font-size: 50px;
-    // 画像が表示されるようになったらここから下の２行は消す
-    background-color: rgba(255,0,0, 0.7);
-    color: #fff;
-    &:focus{
-      outline:none;
+
+    .slider__list{
+      margin: 0px;
+      img {
+        width: 300px;
+        height: 300px;
+      }
+      &:focus{
+        outline:none;
+      }
     }
   }
   .draggable{
     padding:0px !important;
-    .thumb__list{
-      width: 60px !important;
-      height: 60px;
-      opacity: 0.7;
-      margin: 0px;
-      outline:none;
-      // 画像が表示されるようになったらここから下の２行は消す
-      background-color: rgba(0, 0,255, 0.7);
-      color: #fff;
+    .slick-track{
+      transform: translate3d(0px, 0px, 0px) !important;
+      float: left;
+      .thumb__list{
+        width: 60px !important;
+        height: 60px;
+        opacity: 0.7;
+        margin: 0px;
+        outline:none;
+
+        img {
+          width: 60px;
+          height: 60px;
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/carousel/slick-theme.scss
+++ b/app/assets/stylesheets/carousel/slick-theme.scss
@@ -204,7 +204,7 @@ $slick-opacity-not-active: 0.8 !default;
     height: 300px;
     font-size: 50px;
 
-    .slider__list{
+    &__list{
       margin: 0px;
       img {
         width: 300px;
@@ -317,62 +317,62 @@ $slick-opacity-not-active: 0.8 !default;
 }
 
 .slick-dots {
-    position: absolute;
-    bottom: 15px;
-    list-style: none;
-    display: block;
-    text-align: center;
+  position: absolute;
+  bottom: 15px;
+  list-style: none;
+  display: block;
+  text-align: center;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  li {
+    position: relative;
+    display: inline-block;
+    height: 20px;
+    width: 20px;
+    margin: 0 5px;
     padding: 0;
-    margin: 0;
-    width: 100%;
-    li {
-        position: relative;
-        display: inline-block;
-        height: 20px;
+    cursor: pointer;
+    button {
+      border: 0;
+      background: transparent;
+      display: block;
+      height: 20px;
+      width: 20px;
+      outline: none;
+      line-height: 0px;
+      font-size: 0px;
+      color: transparent;
+      padding: 5px;
+      cursor: pointer;
+      &:hover, &:focus {
+        outline: none;
+        &:before {
+          opacity: $slick-opacity-on-hover;
+        }
+      }
+      &:before {
+        position: absolute;
+        top: 0;
+        left: 0;
+        content: $slick-dot-character2;
         width: 20px;
-        margin: 0 5px;
-        padding: 0;
-        cursor: pointer;
-        button {
-            border: 0;
-            background: transparent;
-            display: block;
-            height: 20px;
-            width: 20px;
-            outline: none;
-            line-height: 0px;
-            font-size: 0px;
-            color: transparent;
-            padding: 5px;
-            cursor: pointer;
-            &:hover, &:focus {
-                outline: none;
-                &:before {
-                    opacity: $slick-opacity-on-hover;
-                }
-            }
-            &:before {
-                position: absolute;
-                top: 0;
-                left: 0;
-                content: $slick-dot-character2;
-                width: 20px;
-                height: 20px;
-                font-family: "Font Awesome 5 Free";
-                font-weight:900;
-                font-size: $slick-dot-size;
-                line-height: 20px;
-                text-align: center;
-                color: $white;
-                opacity: 0.7;
-                -webkit-font-smoothing: antialiased;
-                -moz-osx-font-smoothing: grayscale;
-            }
-        }
-        &.slick-active button:before {
-            color: $slick-dot-color-active;
-            opacity: $slick-opacity-default;
-        }
+        height: 20px;
+        font-family: "Font Awesome 5 Free";
+        font-weight:900;
+        font-size: $slick-dot-size;
+        line-height: 20px;
+        text-align: center;
+        color: $white;
+        opacity: 0.7;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
     }
+  &.slick-active button:before {
+    color: $slick-dot-color-active;
+    opacity: $slick-opacity-default;
+  }
+  }
 }
 }

--- a/app/assets/stylesheets/items/show-detail.scss
+++ b/app/assets/stylesheets/items/show-detail.scss
@@ -14,10 +14,10 @@
         clear:both;
         &__photo{
           display: block;
-          width: 270px;
+          width: 300px;
           height: 360px;
           margin: 0 auto;
-          background:url("https://placehold.jp/cccccc/ffffff/150x150.png?text=item-photo");
+          background-color:$gray-lv1;
         }
         &__price{
           margin-top: 24px;
@@ -28,7 +28,7 @@
             font-size:0.2em;
             font-weight:normal;
           }
-          &__sipping{
+          &__shipping{
             font-size:0.3em;
             font-weight:normal;
           }

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,13 +1,10 @@
-.wrapper
+.wrapper.index-page
   = render 'shared/header'
 
   %main
     %section.slick
-      %figure.slick-list=image_tag "slider_01.png", alt: "スライダーの画像", class: "slick-list__image"
-      %figure.slick-list=image_tag "slider_02.png", alt: "スライダーの画像", class: "slick-list__image"
-      %figure.slick-list=image_tag "slider_03.png", alt: "スライダーの画像", class: "slick-list__image"
-      %figure.slick-list=image_tag "slider_04.png", alt: "スライダーの画像", class: "slick-list__image"
-
+      %figure.slick-list=image_tag "https://www.mercari.com/jp/assets/img/common/jp/top/banner-camp.jpg", alt: "スライダーの画像", class: "slick-list__image"
+      %figure.slick-list=image_tag "https://www.mercari.com/jp/assets/img/common/jp/top/banner-natsukashi.jpg", alt: "スライダーの画像", class: "slick-list__image"
 
   %section.pick-up-container
     %h2.pick-up-container__header ピックアップカテゴリー

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -3,8 +3,10 @@
 
   %main
     %section.slick
-      %figure.slick-list=image_tag "https://www.mercari.com/jp/assets/img/common/jp/top/banner-camp.jpg", alt: "スライダーの画像", class: "slick-list__image"
-      %figure.slick-list=image_tag "https://www.mercari.com/jp/assets/img/common/jp/top/banner-natsukashi.jpg", alt: "スライダーの画像", class: "slick-list__image"
+      %figure.slick-list=image_tag "slider_01.png", alt: "スライダーの画像", class: "slick-list__image"
+      %figure.slick-list=image_tag "slider_02.png", alt: "スライダーの画像", class: "slick-list__image"
+      %figure.slick-list=image_tag "slider_03.png", alt: "スライダーの画像", class: "slick-list__image"
+      %figure.slick-list=image_tag "slider_04.png", alt: "スライダーの画像", class: "slick-list__image"
 
   %section.pick-up-container
     %h2.pick-up-container__header ピックアップカテゴリー

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,12 +8,22 @@
         = @item.name
       .item-info
         .item-info__photo
+          %section.slider
+            - @item.images[1..5].each do |image|
+              %figure.slider__list=image
+
+          %section.thumb
+            - @item.images[1..5].each do |image|
+              %figure.thumb__list=image
+
       .visible-sp-only
         .item-info__price
           %p
             = "￥#{@item.price}"
             %span.item-info__price__tax (税込)
-            %span.item-info__price__sipping
+
+            %span.item-info__price__shipping
+
             = @item.delivery_cost
         .sales-message
           - if user_signed_in?

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -14,6 +14,7 @@
           %section.thumb
             %figure.thumb__list= image_tag ("https://placehold.jp/63b9eb/ffffff/150x150.png?text=%EF%BC%91")
             %figure.thumb__list= image_tag ("https://placehold.jp/63eb75/ffffff/400x400.png?text=2")
+          -# DBの画像表示の異常が解決したらコメントアウトを外す
           -# %section.slider
           -#   - @item.images[0..4].each do |image|
           -#     %figure.slider__list= image_tag(url_for(:action => 'show', :id => image.item_id))

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -9,12 +9,18 @@
       .item-info
         .item-info__photo
           %section.slider
-            - @item.images[1..5].each do |image|
-              %figure.slider__list=image
-
+            %figure.slider__list= image_tag ("https://placehold.jp/63b9eb/ffffff/150x150.png?text=%EF%BC%91")
+            %figure.slider__list= image_tag ("https://placehold.jp/63eb75/ffffff/400x400.png?text=2")
           %section.thumb
-            - @item.images[1..5].each do |image|
-              %figure.thumb__list=image
+            %figure.thumb__list= image_tag ("https://placehold.jp/63b9eb/ffffff/150x150.png?text=%EF%BC%91")
+            %figure.thumb__list= image_tag ("https://placehold.jp/63eb75/ffffff/400x400.png?text=2")
+          -# %section.slider
+          -#   - @item.images[0..4].each do |image|
+          -#     %figure.slider__list= image_tag(url_for(:action => 'show', :id => image.item_id))
+
+          -# %section.thumb
+          -#   - @item.images[0..4].each do |image|
+          -#     %figure.slider__list= image_tag(url_for(:action => 'show', :id => image.item_id))
 
       .visible-sp-only
         .item-info__price

--- a/app/views/shared/_items-box.html.haml
+++ b/app/views/shared/_items-box.html.haml
@@ -1,18 +1,17 @@
 .item-box__container
   - @items.each do |item|
     %section.item-box
-      = link_to item_path(:id) do
-        = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item1")
-        -# データベースのデータが整ったらコメントアウトを外す
-        -# = image_tag item.images[0].image
-      .visible-small-and-sp-only
-        %p= "¥ #{item.price}"
-      .item-box__info
-        %h3.item-box__info__name
-          = item.name
-        .item-box__bottom
-          %p.item-box__bottom__price
-            ¥
-            = item.price
-          %p.item-box__bottom__like.icon-like 1
-          %p.item-box__bottom__tax (税込)
+      = link_to item_path(id: item.id) do
+        = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item1"), class: '.item-box__photo'
+        -# = image_tag ("#"), alt: #{'出品タイトル'}, class: #{'ブランド名'} バックエンドができればこちらに差し替え
+        .visible-small-and-sp-only
+          %p= "¥ #{item.price}"
+        .item-box__info
+          %h3.item-box__info__name
+            = item.name
+          .item-box__bottom
+            %p.item-box__bottom__price
+              ¥
+              = item.price
+            %p.item-box__bottom__like.icon-like 1
+            %p.item-box__bottom__tax (税込)

--- a/app/views/shared/_items-box.html.haml
+++ b/app/views/shared/_items-box.html.haml
@@ -1,15 +1,18 @@
 .item-box__container
   - @items.each do |item|
     %section.item-box
-      = link_to item_path(id: item.id) do
-        = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item1"), class: '.item-box__photo'
-        -# = image_tag ("#"), alt: #{'出品タイトル'}, class: #{'ブランド名'} バックエンドができればこちらに差し替え
-        .item-box__info
-          %h3.item-box__info__name
-            = item.name
-          .item-box__bottom
-            %p.item-box__bottom__price
-              ¥
-              = item.price
-            %p.item-box__bottom__like.icon-like 1
-            %p.item-box__bottom__tax (税込)
+      = link_to item_path(:id) do
+        = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item1")
+        -# データベースのデータが整ったらコメントアウトを外す
+        -# = image_tag item.images[0].image
+      .visible-small-and-sp-only
+        %p= "¥ #{item.price}"
+      .item-box__info
+        %h3.item-box__info__name
+          = item.name
+        .item-box__bottom
+          %p.item-box__bottom__price
+            ¥
+            = item.price
+          %p.item-box__bottom__like.icon-like 1
+          %p.item-box__bottom__tax (税込)


### PR DESCRIPTION
# What
商品詳細ページのカルーセルの実装です
画像表示はまだ全ページで表示されない状況なので、引き続きの検討事項とします

# Why
見た目を改善するためです。

### メンターの方へ
特に、プラグインのコンテンツである、デフォルトのcssの扱い方について（変更して良いものなのか、プラグインがマークアップにStyleを書き込む仕組みになっていたため、!importantを多用して修正せざるを得なかった）など教えいていただけますと幸いです。

### 変更内容
app/assets/javascripts/carousel.js カルーセルの動作
app/assets/stylesheets/carousel/slick-theme.scss slickのデフォルトのcss
app/assets/stylesheets/items/show-detail.scss 商品詳細ページのcss
app/views/items/index.html.haml スライダー加工のためのクラス名追記
app/views/items/show.html.haml　マークアップ変更
app/views/shared/_items-box.html.haml 小さいタイプのitem box用に書き換え
↑すみません、最後の１ファイルは、前に作業していたブランチでの変更内容ですが、うまくプッシュされていなかったようですので、ここにくわえさせてください。

▼動作確認用GIF
[![Image from Gyazo](https://i.gyazo.com/69bce1ff63a037c1091bad25abba5a66.gif)](https://gyazo.com/69bce1ff63a037c1091bad25abba5a66)