### PR TITLE
出品状態 カラムの追加

### DIFF
--- a/db/migrate/20190524043027_add_column_status_to_item.rb
+++ b/db/migrate/20190524043027_add_column_status_to_item.rb
@@ -1,0 +1,5 @@
+class AddColumnStatusToItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :integer, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_23_065048) do
+ActiveRecord::Schema.define(version: 2019_05_24_043027) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2019_05_23_065048) do
     t.text "detail"
     t.integer "delivery_prefecture", null: false
     t.integer "delivery_method", null: false
+    t.integer "status", default: 1, null: false
     t.index ["name"], name: "index_items_on_name"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -70,6 +70,7 @@ end
     detail: "この文章は商品説明用です！この商品のIDは#{num}です！yay!",
     delivery_prefecture: rand(1..48),
     delivery_method: rand(1..9)
+    status: rand(0..2)
     )
 end
 


### PR DESCRIPTION
# What
Itemモデルにstatusカラムの追加。(defailt値は1)
カラム変更に伴うseedファイルの更新。

補足
localでmigrate済み。

# Why
出品者が出品状況を判断できるようにするため。
出品状況によってuserに公開するitemsをソートするため。