### PR TITLE
商品出品ページにアクセスできないエラーの解消

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -91,7 +91,7 @@ class ItemsController < ApplicationController
   private
 
   def params_new
-    params.require(:item).permit(:name, :condition, :detail, :delivery_method, :delivery_prefecture, :delivery_cost, :delivery_day, :price,:category_id, :seller_id, images_attributes: [:image])
+    params.require(:item).permit(:name, :condition, :detail, :delivery_method, :delivery_prefecture, :delivery_cost, :delivery_day, :price, :seller_id, :category_id, images_attributes: [:image])
   end
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -91,7 +91,7 @@ class ItemsController < ApplicationController
   private
 
   def params_new
-    params.require(:item).permit(:name, :condition, :detail, :delivery_method, :delivery_prefecture, :delivery_cost, :delivery_day, :price, :seller_id, images_attributes: [:image])
+    params.require(:item).permit(:name, :condition, :detail, :delivery_method, :delivery_prefecture, :delivery_cost, :delivery_day, :price,:category_id, :seller_id, images_attributes: [:image])
   end
 
   def set_item

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -40,16 +40,16 @@
               .relative
                 .icon-select
                   -# TODO: カテゴリーを格納するデータをどうする？ansectory
-                  = f.select :category_ids, [["レディース", "1"], ["メンズ", "2"], ["ベビー・キッズ", "3"], ["インテリア・住まい・小物", "4"], ["本・音楽・ゲーム", "5"], ["おもちゃ・ホビー・グッズ", "1328"], ["コスメ・香水・美容", "6"], ["家電・スマホ・カメラ", "7"], ["スポーツ・レジャー", "8"], ["ハンドメイド", "9"], ["チケット", "1027"], ["自動車・オートバイ", "1318"], ["その他", "10"]], {include_blank: true}, class: "input-part__select"
+                  = f.select :category_id, [["レディース", "1"], ["メンズ", "2"], ["ベビー・キッズ", "3"], ["インテリア・住まい・小物", "4"], ["本・音楽・ゲーム", "5"], ["おもちゃ・ホビー・グッズ", "1328"], ["コスメ・香水・美容", "6"], ["家電・スマホ・カメラ", "7"], ["スポーツ・レジャー", "8"], ["ハンドメイド", "9"], ["チケット", "1027"], ["自動車・オートバイ", "1318"], ["その他", "10"]], {include_blank: true}, class: "input-part__select"
               -# TODO: 特定カ11テゴリの場合 .hiddenをつける、外す JS
               .relative.hidden
                 .icon-select
                   -# TODO: カテゴリーを格納するデータをどうする？ansectory
-                  = f.select :category_ids, [["レディース", "1"], ["メンズ", "2"]], {include_blank: true}, class: "input-part__select"
+                  = f.select :category_id, [["レディース", "1"], ["メンズ", "2"]], {include_blank: true}, class: "input-part__select"
               .relative.hidden
                 .icon-select
                   -# TODO: カテゴリーを格納するデータをどうする？ansectory
-                  = f.select :category_ids, [["レディース", "1"], ["メンズ", "2"]], {include_blank: true}, class: "input-part__select"
+                  = f.select :category_id, [["レディース", "1"], ["メンズ", "2"]], {include_blank: true}, class: "input-part__select"
               .space.hidden
               .input-part
                 = f.label "サイズ", class: "input-part__title"
@@ -57,13 +57,13 @@
               .relative
                 .icon-select
                   -# TODO: 特定カテゴリ展開時のみ表示させる、連動した条件バリデーション。
-                  = f.select :category_ids, [["XXS以下", "153"], ["XS(SS)", "154"], ["S", "2"], ["M", "3"], ["L", "4"], ["XL(LL)", "5"], ["2XL(3L)", "155"], ["4XL(5L)以上", "157"], ["FREE SIZE", "7"]], {include_blank: true}, class: "input-part__select"
+                  = f.select :category_id, [["XXS以下", "153"], ["XS(SS)", "154"], ["S", "2"], ["M", "3"], ["L", "4"], ["XL(LL)", "5"], ["2XL(3L)", "155"], ["4XL(5L)以上", "157"], ["FREE SIZE", "7"]], {include_blank: true}, class: "input-part__select"
               .space.hidden
               .input-part
                 = f.label "ブランド", class: "input-part__title"
                 %span.input-part__option 任意
                 -# TODO: 特定カテゴリ展開時のみ表示させる。
-                = f.text_field :category_ids, class: "input-part__input", placeholder: "例）シャネル", value: ""
+                = f.text_field :category_id, class: "input-part__input", placeholder: "例）シャネル", value: ""
               .input-part.space
                 = f.label "商品の状態", class: "input-part__title"
                 %span.input-part__require 必須

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,7 +72,7 @@ end
     delivery_prefecture: rand(1..48),
     delivery_method: rand(1..9),
     status: rand(0..2),
-    category_id: rand(0..10)
+    category_id: rand(1..10)
     )
 end
 


### PR DESCRIPTION
# WHAT
出品ページの:category_idsを:category_idに修正
itemsのストロングパラメータにcategory_idを追加
seedファイルを微修正（caetgory_idが0のitemが作られないようにする）

**現在ブランドの欄に数字でカテゴリーidを打ち込まないと出品できません**
**itemsテーブルにないサイズとブランドをどうするか要相談**

# WHY
商品出品ページにアクセスできるようにするため。