### PR TITLE
enum設定変更、enum呼び出し関数の修正、routeing変更でのsetメソッド修正対応

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,7 @@
 class ItemsController < ApplicationController
 
   require 'payjp'
-  before_action :set_item, only: [:show, :destroy]
-  before_action :set_params_item_id, only: [:confirm, :pay]
+  before_action :set_item, only: [:show, :destroy, :confirm, :pay]
   before_action :set_category, only: [:index, :show, :search]
 
 
@@ -81,10 +80,6 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
-  end
-
-  def set_params_item_id
-    @item = Item.find(params[:item_id])
   end
 
   def set_category_items(name)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
 
   require 'payjp'
   before_action :set_item, only: [:show, :destroy, :edit, :confirm, :pay]
-  before_action :set_params_item_id, only: [:confirm, :pay]
   before_action :set_categories, only: [:index, :show, :search, :new, :create]
 
   def index # トップページ、アイテムをカテゴリー別に最新投稿順番に

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,11 @@
 class ItemsController < ApplicationController
-  
+
   require 'payjp'
   before_action :set_item, only: [:show, :destroy]
   before_action :set_params_item_id, only: [:confirm, :pay]
   before_action :set_category, only: [:index, :show, :search]
 
-  
+
   def index # トップページ、アイテムをカテゴリー別に最新投稿順番に
     @ladies_items = set_category_items('レディース')
     @mens_items = set_category_items('メンズ')

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -13,7 +13,7 @@
             %p.item-info__price
               ="¥#{@item.price}"
               %span.item-info__price__shipping
-                = @item.delivery_cost
+                = @item.delivery_cost_i18n
                 -# ポイントがある場合とない場合で表示が切り替わります。余裕があれば追加
                 -# %ul.buy-accordion.not-have
                 -#   %li.buy-accordion__inner
@@ -35,7 +35,7 @@
               %p
                 = "〒#{current_user.postal_code.to_s.insert(3, '-')}"
                 %br
-                = "#{current_user.prefecture} #{current_user.city}"
+                = "#{current_user.prefecture_i18n} #{current_user.city}"
                 %br
                 = current_user.address
                 %br
@@ -45,7 +45,7 @@
 
               %p.link-to-change.icon-arrow-r
                 =link_to "変更する", edit_path(url:"identification")
-                
+
           -# 支払い情報がnillだとグレーのボタンとなり購入できないが、とりあえず無視する
           %hr.line
           .card-info

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -79,30 +79,30 @@
           %tr
             %th 商品の状態
             %td
-              = @item.condition
+              = @item.condition_i18n
           %tr
             %th 配送料の負担
             %td
-              = @item.delivery_cost
+              = @item.delivery_cost_i18n
           %tr
             %th 配送の方法
             %td
-              = @item.delivery_method
+              = @item.delivery_method_i18n
           %tr
             %th 配送元地域
             %td
               %p.detail_link
-                =link_to "#{@item.delivery_prefecture}", '#'
+                =link_to "#{@item.delivery_prefecture_i18n}", '#'
           %tr
             %th 発送日の目安
             %td
-              =@item.delivery_day
+              =@item.delivery_day_i18n
       .item-info
         .item-info__price
           %p
             = "￥#{@item.price}"
             %span.item-info__price__tax (税込)
-            %span.item-info__price__shipping= @item.delivery_cost
+            %span.item-info__price__shipping= @item.delivery_cost_i18n
 
         - if user_signed_in?
           .sales-message

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,10 +11,14 @@ module FreemarketSample50teama
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    # config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    # config.i18n.default_locale = :ja
+    # config.i18n.available_locales = [:ja, :en]
+
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :ja
-    config.i18n.available_locales = [:ja, :en]
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,17 @@
 ja:
+  activerecord:
+    models:
+      user: ユーザ情報
+      item: 商品情報
+    attributes:
+      user:
+        prefecture: 都道府県
+      item:
+        delivery_prefecture: 発送元の地域
+        condition: 商品の状態
+        delivery_cost: 配送料の負担
+        delivery_method: 発送の方法
+        delivery_day: 発送までの日数
   date:
     formats:
       default: "%Y/%m/%d"


### PR DESCRIPTION
# What?
### ルーティング変更によるparams値の修正、既存set関数との統合
app/controllers/items_controller.rb

これにより、
商品詳細 => 購入画面に進む => 購入する
の動作でエラーなく表示されることを確認

### gem enum_help対象変数に対してja.ymlのi18n化を適用させる
app/views/items/confirm.html.haml
app/views/items/show.html.haml

**以後同様のことがしたい場合、enumの名前_i18n**
**で日本語文字列化させることができます。**

i18nってなんぞと思ったらi (nternationalizatio) n
()が18文字っていう、単なる国際標準化の短縮表現だった。

### gem enum_helpの設定部分修正、ja.yml内に対応modelの記述
config/application.rb
config/locales/ja.yml
正直、これで完全に大丈夫かというとわからないので
今後ja.ymlに起因するエラーが発生した場合には再度修正検討対象


# Why?
諸々発生したバグフィックス

# 日本語化実装画面
![FreemarketSample50teama (1)](https://user-images.githubusercontent.com/46148545/58366198-c222bb00-7f09-11e9-90cb-bda0ebfd4c37.png)
![FreemarketSample50teama](https://user-images.githubusercontent.com/46148545/58366202-c8189c00-7f09-11e9-8c0d-e3a9e2c3ab13.png)
