### PR TITLE
画像パスの修正、トップページレコードのセレクトステータス

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -93,6 +93,6 @@ class ItemsController < ApplicationController
   end
 
   def set_category_items(name)
-    Item.where(category_id: Category.find_by(name: name).id).order(id: "DESC").limit(4)
+    Item.where(category_id: Category.find_by(name: name).id, status: 1).order(id: "DESC").limit(4)
   end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -12,20 +12,11 @@
             .soldout-color
             .soldout
           %section.slider
-            %figure.slider__list= image_tag ("https://placehold.jp/63b9eb/ffffff/150x150.png?text=%EF%BC%91")
-            %figure.slider__list= image_tag ("https://placehold.jp/63eb75/ffffff/400x400.png?text=2")
+            - @item.images.each do |image|
+              %figure.slider__list= image_tag image.image.to_s if image.image.to_s
           %section.thumb
-            %figure.thumb__list= image_tag ("https://placehold.jp/63b9eb/ffffff/150x150.png?text=%EF%BC%91")
-            %figure.thumb__list= image_tag ("https://placehold.jp/63eb75/ffffff/400x400.png?text=2")
-
-          -# DBの画像表示の異常が解決したらコメントアウトを外す
-          -# %section.slider
-          -#   - @item.images[0..4].each do |image|
-          -#     %figure.slider__list= image_tag(url_for(:action => 'show', :id => image.item_id))
-
-          -# %section.thumb
-          -#   - @item.images[0..4].each do |image|
-          -#     %figure.slider__list= image_tag(url_for(:action => 'show', :id => image.item_id))
+            - @item.images.each do |image|
+              %figure.thumb__list= image_tag image.image.to_s if image.image.to_s
 
       .visible-sp-only
         .item-info__price

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -70,30 +70,30 @@
           %tr
             %th 商品の状態
             %td
-              = @item.condition
+              = @item.condition_i18n
           %tr
             %th 配送料の負担
             %td
-              = @item.delivery_cost
+              = @item.delivery_cost_i18n
           %tr
             %th 配送の方法
             %td
-              = @item.delivery_method
+              = @item.delivery_method_i18n
           %tr
             %th 配送元地域
             %td
               %p.detail_link
-                =link_to "#{@item.delivery_prefecture}", '#'
+                =link_to "#{@item.delivery_prefecture_i18n}", '#'
           %tr
             %th 発送日の目安
             %td
-              =@item.delivery_day
+              =@item.delivery_day_i18n
       .item-info
         .item-info__price
           %p
             = "￥#{@item.price}"
             %span.item-info__price__tax (税込)
-            %span.item-info__price__shipping= @item.delivery_cost
+            %span.item-info__price__shipping= @item.delivery_cost_i18n
 
         - if user_signed_in?
           .sales-message

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -13,10 +13,10 @@
             .soldout
           %section.slider
             - @item.images.each do |image|
-              %figure.slider__list= image_tag image.image.to_s if image.image.to_s
+              %figure.slider__list= image_tag image.image.to_s
           %section.thumb
             - @item.images.each do |image|
-              %figure.thumb__list= image_tag image.image.to_s if image.image.to_s
+              %figure.thumb__list= image_tag image.image.to_s
 
       .visible-sp-only
         .item-info__price

--- a/app/views/shared/_items-box.html.haml
+++ b/app/views/shared/_items-box.html.haml
@@ -2,7 +2,7 @@
   - items.each do |item|
     %section.item-box
       = link_to item_path(id: item.id) do
-        = image_tag ("https://placehold.jp/b3b3b3/ffffff/200x200.png?text=item1"), class: '.item-box__photo'
+        = image_tag item.images[0].image.to_s, class: 'item-box__photo'
         -# = image_tag ("#"), alt: #{'出品タイトル'}, class: #{'ブランド名'} バックエンドができればこちらに差し替え
         -if item.status == 2
           .soldout-color


### PR DESCRIPTION
# What?
### 画像ファイルパス表記の修正
app/views/shared/_items-box.html.haml
seedカテゴリがランダムなため写真とカテゴリは合ってません
app/views/items/show.html.haml
他プルリクで出してますが、ついでにenumシンボルの日本語文字列化をさせてます。

### トップページには販売中のものだけ表示
app/controllers/items_controller.rb
私の現在のrandではレディースstatus=1がゼロだったためレディース表示は消えました。

### 既知の不具合
sliderによるサムネが５枚までしか表示されません
eachで全て出してるはずなのでレイアウト上の制限がかかってる？

# Why?
DBから画像を表示させる

# 表示サンプル
![FreemarketSample50teama (3)](https://user-images.githubusercontent.com/46148545/58375164-05237380-7f88-11e9-914d-ca37919213ee.png)

<a href="https://gyazo.com/f5bba444c026fe368b7fb102d7e754d5"><img src="https://i.gyazo.com/f5bba444c026fe368b7fb102d7e754d5.gif" alt="Image from Gyazo" width="776"/></a>
