### PR TITLE
商品詳細ページと購入確認ページのレスポンシブ化

### DIFF
--- a/app/assets/stylesheets/items/buy-confirm.scss
+++ b/app/assets/stylesheets/items/buy-confirm.scss
@@ -2,7 +2,7 @@
   .single-container{
     .panel {
       background: $white;
-      width: 700px;
+      width: 100%;
       margin: 0 auto 41px;
       &__head{
         padding: 37px 16px 38px;
@@ -100,4 +100,14 @@
       }
     }//end panel
   } // end single container
+
+  @media screen and (min-width: 768px) {
+    .single-container{
+      .panel {
+        background: $white;
+        width: 700px;
+        margin: 0 auto 41px;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/items/show-detail.scss
+++ b/app/assets/stylesheets/items/show-detail.scss
@@ -3,7 +3,7 @@
     @include single-container-base;
     margin: 40px auto;
     padding: 24px 16px;
-
+    width: 100%;
     .panel{
       &__head{
         @include single-container-header;
@@ -22,7 +22,7 @@
           .soldout::before{
             content: "";
             top: 0;
-            left: 0;  
+            left: 0;
             border-bottom: 120px solid transparent;
             border-left: 120px solid $base-red;
             position: absolute;
@@ -34,7 +34,7 @@
             font-weight: bold;
             display: block;
             top: 30px;
-            transform: rotate(-45deg); 
+            transform: rotate(-45deg);
             color: #fff;
             left: 10px;
             position: absolute;
@@ -106,6 +106,9 @@
       font-size: 24px;
       font-weight: normal;
       margin-bottom:20px;
+      a {
+        display: block;
+      }
     }
     .sales-message{
       @include green-balloon;
@@ -135,7 +138,7 @@
       display: block;
       text-align: right;
       color: $link-blue;
-      line-height: 2.5em;
+      padding-top: 2px;
       flex: 2;
       &:hover{
         @include blue-link;
@@ -160,7 +163,7 @@
     background-color: $white;
     margin: 40px auto;
     padding: 24px 40px;
-    width: 700px;
+    width: 100%;
     display: flex;
     justify-content:center;
     align-items: center;
@@ -200,27 +203,31 @@
 }//item-detail-page end
 
 @media screen and (min-width: 768px) {
-.item-detail-page{
-  .single-container{
-    .visible-sp-only{
-      display: none;
-    }
-    .item-info{
-      &__photo{
-        float: left;
+  .item-detail-page{
+    .single-container{
+      width: 700px;
+      .visible-sp-only{
+        display: none;
       }
-      &__price{
-        padding-top: 30px;
-        clear: both;
+      .item-info{
+        &__photo{
+          float: left;
+        }
+        &__price{
+          padding-top: 30px;
+          clear: both;
+        }
+      }
+      .detail-info{
+        float: right;
+        width: 320px;
       }
     }
-    .detail-info{
-      float: right;
-      width: 320px;
-    }
-  }
-  .other-item{
+    .other-item{
     width: 700px !important;
+    }
+    .sns-wrapper {
+      width: 700px;
     }
   }
 }//幅768px以上のページに適応されるscss

--- a/app/assets/stylesheets/items/show-detail.scss
+++ b/app/assets/stylesheets/items/show-detail.scss
@@ -100,6 +100,14 @@
       margin-top: 30px;
 
     }
+    .sold-out-btn {
+      @include btn-default;
+      @include btn-gray;
+      font-size: 24px;
+      font-weight: normal;
+      margin:10px 0 20px;
+      cursor: not-allowed;
+    }
     .buy-btn{
       @include btn-default;
       @include btn-red;

--- a/app/assets/stylesheets/items/show-detail.scss
+++ b/app/assets/stylesheets/items/show-detail.scss
@@ -183,6 +183,7 @@
     padding: 15px;
     text-align: center;
     font-size:1.2em;
+    width: 100%;
 
     .edit-item__btn, .suspend-item__btn, .delete-item__btn{
       @include btn-reset;
@@ -229,5 +230,9 @@
     .sns-wrapper {
       width: 700px;
     }
+    .myItem-container {
+      width: 700px;
+    }
   }
+
 }//幅768px以上のページに適応されるscss

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -26,18 +26,18 @@
 
 
       .visible-sp-only
-        .item-info__price
-          %p
-            = "￥#{@item.price}"
-            %span.item-info__price__tax (税込)
+        .item-info
+          .item-info__price
+            %p
+              = "￥#{@item.price}"
+              %span.item-info__price__tax (税込)
+              %span.item-info__price__shipping= @item.delivery_cost_i18n
 
-            %span.item-info__price__shipping
-              = @item.delivery_cost
-
-        .sales-message
           - if user_signed_in?
-            ="売上金#{current_user.money}円をお持ちです"
-        .buy-btn 購入画面に進む
+            .sales-message
+              ="売上金#{current_user.money}円をお持ちです"
+          .buy-btn
+            = link_to "購入画面に進む", confirm_item_path(params[:id])
       %table.detail-info
         %tbody
           %tr

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -56,19 +56,19 @@
             %td.detail-info__category
               - if @item.category.has_parent? && @item.category.parent.has_parent?
                 %p.detail_link
-                  =link_to @item.category.parent.parent.name, '#'
+                  =link_to @item.category.parent.parent.name, category_path(id: @item.category.parent.parent.id)
                 %p.icon-arrow-right.detail_link
-                  =link_to @item.category.parent.name, '#'
+                  =link_to @item.category.parent.name, category_path(id: @item.category.parent.id)
                 %p.icon-arrow-right.detail_link
-                  =link_to @item.category.name, '#'
+                  =link_to @item.category.name, category_path(id: @item.category.id)
               - elsif @item.category.has_parent?
                 %p.detail_link
-                  =link_to @item.category.parent.name, '#'
+                  =link_to @item.category.parent.name, category_path(id: @item.category.parent.id)
                 %p.icon-arrow-right.detail_link
-                  =link_to @item.category.name, '#'
+                  =link_to @item.category.name, category_path(id: @item.category.id)
               - else
                 %p.detail_link
-                  =link_to @item.category.name, '#'
+                  =link_to @item.category.name, category_path(id: @item.category.id)
           %tr
             %th ブランド
             %td.detail-info__brand

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -33,11 +33,14 @@
               %span.item-info__price__tax (税込)
               %span.item-info__price__shipping= @item.delivery_cost_i18n
 
-          - if user_signed_in?
+          - if user_signed_in? && @item.status != 2
             .sales-message
               ="売上金#{current_user.money}円をお持ちです"
-          .buy-btn
-            = link_to "購入画面に進む", confirm_item_path(params[:id])
+          - if @item.status == 2
+            .sold-out-btn 売り切れました
+          - else
+            .buy-btn
+              = link_to "購入画面に進む", confirm_item_path(params[:id])
       %table.detail-info
         %tbody
           %tr
@@ -102,11 +105,14 @@
             %span.item-info__price__tax (税込)
             %span.item-info__price__shipping= @item.delivery_cost_i18n
 
-        - if user_signed_in?
+        - if user_signed_in? && @item.status != 2
           .sales-message
             ="売上金#{current_user.money}円をお持ちです"
-        .buy-btn
-          = link_to "購入画面に進む", confirm_item_path(params[:id])
+        - if @item.status == 2
+          .sold-out-btn 売り切れました
+        - else
+          .buy-btn
+            = link_to "購入画面に進む", confirm_item_path(params[:id])
 
       .item-info__description
         %p


### PR DESCRIPTION
# WHAT
商品詳細ページの編集
・商品のカテゴリにリンクを追加
・画面幅を小さくした時に画面外に要素が飛び出していたのを修正
・未ログイン時で画面幅を小さくすると上の購入ボタンに空の吹き出しが表示されるのを修正
・購入ボタンのリンクをボタン全体に広げる

購入確認ページの編集
・画面幅を小さくした時に画面外に要素が飛び出していたのを修正

# WHY
画面幅が小さい場合でも閲覧しやすくするため