### PR TITLE
右下出品ボタンをページによって非表示にする

### DIFF
--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -54,5 +54,3 @@
       =image_tag "logo-white.svg", size: "124x33", alt: "mercari"
     %span.footer-copyright
       %small © 2019 Mercari
-
-=render 'shared/footer-sell-btn'

--- a/app/views/shared/_mypage-nav.html.haml
+++ b/app/views/shared/_mypage-nav.html.haml
@@ -15,7 +15,7 @@
       =link_to 'いいね！一覧','#'
     %li.mypage-nav__list
       .mypage-nav__list__inner.icon-arrow-r
-      =link_to '出品する','#'
+      =link_to '出品する', new_item_path
     %li.mypage-nav__list
       .mypage-nav__list__inner.icon-arrow-r
       =link_to '出品した商品 - 出品中','#'

--- a/app/views/users/mypage/identification.html.haml
+++ b/app/views/users/mypage/identification.html.haml
@@ -67,3 +67,4 @@
   = render '/shared/mypage-nav'
 = render 'shared/aside'
 = render 'shared/footer'
+=render 'shared/footer-sell-btn'

--- a/app/views/users/mypage/logout.html.haml
+++ b/app/views/users/mypage/logout.html.haml
@@ -10,3 +10,4 @@
 
 = render 'shared/aside'
 = render 'shared/footer'
+=render 'shared/footer-sell-btn'

--- a/app/views/users/mypage/profile.html.haml
+++ b/app/views/users/mypage/profile.html.haml
@@ -26,3 +26,4 @@
     %p.footer_sell_btn__litter 出品
     %p.icon-camera
   -# ↑このボタンはリファクタリング対象
+=render 'shared/footer-sell-btn'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -28,3 +28,4 @@
   = render "shared/mypage-nav"
 = render "shared/aside"
 = render "shared/footer"
+=render 'shared/footer-sell-btn'


### PR DESCRIPTION
# What
各ページにrenderとして切り分けられていたが、footerにも記載があったため、footerのあるページ全てに表示されていた。
footerのrenderを削除。

## 表示
・items
index / search
・users
  show / identification / logout /prifile
・categories
show
・cards
  index / new
## 非表示
・items
  show / confirm / new / edit
・users
  new / signup

# Why
出品することに重きをおくために基本出品ボタンは出ているが、
買う意識になっている場合(商品詳細や購入確認ページ)には非表示にすることで意識のノイズを消す。