### PR TITLE
items_controller(searchアクション)のテスト,items_controllerの不具合修正

### DIFF
--- a/app/assets/javascripts/mordal-window.js
+++ b/app/assets/javascripts/mordal-window.js
@@ -1,4 +1,4 @@
-$(document).on('turebolinks:load', $(function(){
+$(document).on('turbolinks:load', $(function(){
   window.onload = function() {
     $("#modal-open").on('click', function(){
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -67,7 +67,6 @@ class ItemsController < ApplicationController
     if @items.count == Item.all.count || params[:keyword].present? == false
       @all_items = Item.order(id: "DESC").limit(40)
     end
-    # 余裕があればkaminariを入れて、limit(40)を外す
   end
 
   def destroy

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -63,8 +63,9 @@ class ItemsController < ApplicationController
 
   def search
     @items = Item.where('name LIKE(?)', "%#{params[:keyword]}%").limit(40)
+    @all_items = Item.order(id: "DESC").limit(40)
     if @items.count == Item.all.count || params[:keyword].present? == false
-      @items = Item.order(id: "DESC").limit(40)
+      @all_items = Item.order(id: "DESC").limit(40)
     end
     # 余裕があればkaminariを入れて、limit(40)を外す
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -64,9 +64,6 @@ class ItemsController < ApplicationController
   def search
     @items = Item.where('name LIKE(?)', "%#{params[:keyword]}%").limit(40)
     @all_items = Item.order(id: "DESC").limit(40)
-    if @items.count == Item.all.count || params[:keyword].present? == false
-      @all_items = Item.order(id: "DESC").limit(40)
-    end
   end
 
   def destroy

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -83,7 +83,7 @@
           %p.result__message 該当する商品が見つかりません。商品は毎日増えていますので、これからの出品に期待してください。
 
           %h3.new-items 新着商品
-          = render 'shared/items-box', items: @items
+          = render 'shared/items-box', items: @all_items
 
         - else
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -131,7 +131,7 @@
         %button.edit-item__btn=link_to "商品の編集", edit_item_path
         %p or
         %button.suspend-item__btn=link_to "出品を一時停止する", '#'
-        %button.delete-item__btn#modal-open=link_to "この商品を削除する", '#'
+        %button.delete-item__btn#modal-open この商品を削除する
 
     .modal-overlay
       #modal-window.modal

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -33,4 +33,16 @@ describe ItemsController do
       expect(assigns(:same_category_items)).to eq(Item.where(category_id: item.category_id).where.not(id: item.id).order(id: 'DESC').limit(6))
     end
   end
+
+  describe '#search' do
+    before do
+      get :search, params:{ keyword: ""}
+    end
+    it "renders the :search template" do
+      expect(response).to render_template :search
+    end
+    it "assigns the requested items to @all_items" do
+      expect(assigns(:all_items)).to eq(Item.order(id: "DESC").limit(40))
+    end
+  end
 end


### PR DESCRIPTION
# What
items_controller searchアクションのテストです。
ついでに、items_controllerの動きが想定どおりでなかった箇所を修正しました
（検索に一致する結果がなかった時に、新着アイテムが表示されるようにする）

# Why
必須の項目だからです。

### その他
"%#{params[:keyword]}%"を含む@itemのテストについては、今回は諦めることにしました

### testの画像
[![Image from Gyazo](https://i.gyazo.com/8b8d08805ad6340dcab9654dcce73313.png)](https://gyazo.com/8b8d08805ad6340dcab9654dcce73313)

### 一致する結果がなかった時の動き
[![Image from Gyazo](https://i.gyazo.com/b551b650244bec7528b40afc021b81a4.gif)](https://gyazo.com/b551b650244bec7528b40afc021b81a4)