### PR TITLE
カテゴリー表示の修正

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,14 +1,19 @@
 class CategoriesController < ApplicationController
   before_action :set_categories, only: :show
   before_action :set_category, only: :show
+  before_action :set_items, only: :show
 
   def show
-    @items = Item.where(category_id: @category.id)
   end
 
   private
 
   def set_category
     @category = Category.find(params[:id])
+  end
+
+  def set_items
+    category_ids = Category.find(params[:id]).descendant_ids.push(Category.find(params[:id]).id)
+    @items = Item.where(category_id: category_ids, status: 1).order(id: "DESC")
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -88,7 +88,8 @@ class ItemsController < ApplicationController
   end
 
   def set_category_items(name)
-    Item.where(category_id: Category.find_by(name: name).id, status: 1).order(id: "DESC").limit(4)
+    category_ids = Category.find_by(name: name).descendant_ids.push(Category.find_by(name: name).id)
+    return Item.where(category_id: category_ids, status: 1).order(id: "DESC").limit(4)
   end
 
   def set_items_category_id


### PR DESCRIPTION
# WHAT
・トップページで商品一覧を表示する際、子孫カテゴリの商品も表示

・カテゴリ詳細で商品一覧を表示する際、子孫カテゴリの商品も表示

# WHY
カテゴリによる絞り込みを容易にするため