### PR TITLE
商品詳細ページのその他の商品一覧表示の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @items = Item.order(id: 'DESC').limit(4)
-    @same_category_items = Item.where(category_id: @item.category_id).where.not(id: @item.id).order(id: 'DESC').limit(6)
+    @same_user_items = Item.joins(:users).where('users.id = ? AND status = ?', @item.users[0].id, 1).where.not(id: @item.id).order(id: 'DESC').limit(6)
+    category_ids = Category.find(@item.category_id).descendant_ids.push(@item.category_id)
+    @same_category_items = Item.where(category_id: category_ids, status: 1).where.not(id: @item.id).order(id: 'DESC').limit(6)
   end
 
   def confirm

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -162,7 +162,7 @@
   %section.pick-up-container
     %h2.pick-up-container__header
       ="#{@item.users[0].name}さんのその他の出品"
-    = render 'shared/items-box', items: @items
+    = render 'shared/items-box', items: @same_user_items
 
   %section.pick-up-container
     %h2.pick-up-container__header


### PR DESCRIPTION
# WHAT
・同じuserの商品一覧を表示
・同じカテゴリの商品一覧に、子孫カテゴリの商品も表示

# WHY
ユーザが出品したその他の商品を確認するため