### PR TITLE
カテゴリ機能の修正

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -8,6 +8,10 @@ $(document).on('turbolinks:load', function() {
 
   $('.parent-category').change(function(){
     $('.relative--hidden').css('display','none');
+    $('.child-category').prop('disabled', true);
+    $('.child-category').val("");
+    $('.grandchild-category').prop('disabled', true);
+    $('.grandchild-category').val("");
     child_id = $(this).val() + '-children-item';
     $('#' + child_id).css('display','block');
     $('#' + child_id).children().prop('disabled', false);
@@ -15,16 +19,13 @@ $(document).on('turbolinks:load', function() {
 
   $('.child-category').change(function(){
     $('.relative--hidden').css('display','none');
+    $('.grandchild-category').prop('disabled', true);
+    $('.grandchild-category').val("");
     grandchild_id = $(this).val() + '-grandchildren-item';
     $('#' + child_id).css('display','block');
     $('#' + grandchild_id).css('display','block');
     $('#' + grandchild_id).children().prop('disabled', false);
   });
-
-  $('.grandchild-category').change(function(){
-    $(this).prop('disabled', false);
-  });
-
 
   $('.category-show').on("mouseover", function(){
     $('.category-list__parent').css('display','block');


### PR DESCRIPTION
# WHAT
商品出品時においてカテゴリを選択後、他のカテゴリに変更すると、変更前のカテゴリが適応されてしまう不具合を修正

親カテゴリが変更された時、全ての子孫カテゴリをdisabled（フォーム送信しない）、valueを空の状態
その後、選択した親に対応した子カテゴリのみをdisabled: false（フォーム送信する）

子カテゴリが変更された時、全ての孫カテゴリをdisabled（フォーム送信しない）、valueを空の状態
その後、選択した子に対応した子カテゴリのみをdisabled: false（フォーム送信する）

# WHY
期待通りのカテゴリをデータに登録するため